### PR TITLE
Set reset deploy_countdown correctly after deploy

### DIFF
--- a/bots/openprescribing/openprescribing.py
+++ b/bots/openprescribing/openprescribing.py
@@ -213,11 +213,10 @@ def deploy_timer(message):
                      "Error during deploy: {}".format(e))
                 raise
             finally:
+                flags.deploy_countdown = None
                 if flags.deploy_queued:
                     flags.deploy_queued = False
                     deploy_live_delayed(message)
-                else:
-                    flags.deploy_countdown = None
         else:
             sleep(1)
             if flags.deploy_countdown is not None:


### PR DESCRIPTION
This fixes the problem (#29) where merging a third time (while the first
merge is being deployed and the second is enqueued) causes ebmbot to get
into a state where it effectively ignores all further merges.

When a deploy is queued, deploy_countdown should be reset once a deploy
is finished.  Otherwise, the branch in reset_or_deploy_timer() that
kicks off the timer thread never gets run, and future deploys never
actually happen.

I am not confident that there are no other funny edge conditions in the
code, and I'd like to move to using a proper queue system in the future.

I have not added any tests, because the existing tests are flaky.

Fixes #29.