### PR TITLE
Escape job arguments for use in shells, and undo URL formatting

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -56,7 +57,8 @@ class JobDispatcher:
         namespace = self.job["type"].split("_")[0]
         self.cwd = os.path.join(settings.WORKSPACE_DIR, namespace)
         self.fabfile_url = config["fabfiles"].get(namespace)
-        self.run_args = self.job_config["run_args_template"].format(**self.job["args"])
+        escaped_args = {k: shlex.quote(v) for k, v in self.job["args"].items()}
+        self.run_args = self.job_config["run_args_template"].format(**escaped_args)
         self.callback_url = self.build_callback_url()
 
     def start_job(self):

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -10,6 +10,9 @@ raw_config = {
             "paramaterised_job": {
                 "run_args_template": "cat {path}",
             },
+            "paramaterised_job_2": {
+                "run_args_template": "echo {thing_to_echo}",
+            },
             "reported_job": {
                 "run_args_template": "cat poem",
                 "report_stdout": True,
@@ -22,6 +25,9 @@ raw_config = {
             },
             "really_bad_job": {
                 "run_args_template": "dog poem",
+            },
+            "job_with_url": {
+                "run_args_template": "curl {url}",
             },
         },
         "slack": [
@@ -49,6 +55,13 @@ raw_config = {
                 "help": "don't suppress the job",
                 "type": "cancel_suppression",
                 "job_type": "good_job",
+            },
+            {
+                "command": "do url [url]",
+                "help": "do a job with a url",
+                "type": "schedule_job",
+                "job_type": "job_with_url",
+                "delay_seconds": 0,
             },
         ],
     }

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -32,6 +32,15 @@ def test_schedule_job():
     assert_job_matches(jj[0], "test_good_job", {"n": "10"}, "channel", T(60), None)
 
 
+def test_url_formatting_removed():
+    handle_message("test do url <http://www.foo.com>")
+    jj = scheduler.get_jobs_of_type("test_job_with_url")
+    assert len(jj) == 1
+    assert_job_matches(
+        jj[0], "test_job_with_url", {"url": "http://www.foo.com"}, "channel", T(0), None
+    )
+
+
 def test_cancel_job():
     handle_message("test do job 10")
     assert scheduler.get_jobs_of_type("test_good_job")

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -44,6 +44,24 @@ def test_run_once():
     assert not os.path.exists(build_log_dir("test_really_bad_job"))
 
 
+def test_job_success_with_unsafe_shell_args():
+    log_dir = build_log_dir("test_paramaterised_job_2")
+
+    scheduler.schedule_job(
+        "test_paramaterised_job_2", {"thing_to_echo": "<poem>"}, "channel", TS
+    )
+    job = scheduler.reserve_job()
+    with assert_slack_client_sends_messages(
+        web_api=[("logs", "about to start"), ("channel", "succeeded")]
+    ):
+        do_job(job)
+    with open(os.path.join(log_dir, "stdout")) as f:
+        assert f.read() == "<poem>\n"
+
+    with open(os.path.join(log_dir, "stderr")) as f:
+        assert f.read() == ""
+
+
 def test_job_success():
     log_dir = build_log_dir("test_good_job")
 


### PR DESCRIPTION
Special characters like `<` will break shells.

In the case of URL formatting, we remove them, but all the arguments should be escaped anyway.