### PR TITLE
Replace slackbot with fork and upgrade requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ flask
 gunicorn
 requests
 slackbot
+git+https://github.com/ebmdatalab/slackbot.git@d37d27ff470c0991b70fd8cd448d2d1d3a0eda45
 structlog
 
 # development

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,93 +4,101 @@
 #
 #    pip-compile
 #
-attrs==21.2.0
+attrs==22.1.0
     # via pytest
-bcrypt==3.2.0
+bcrypt==3.2.2
     # via paramiko
-black==21.8b0
+black==22.6.0
     # via -r requirements.in
-certifi==2021.5.30
+build==0.8.0
+    # via pip-tools
+certifi==2022.6.15
     # via requests
-cffi==1.14.6
+cffi==1.15.1
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.4
+charset-normalizer==2.1.0
     # via requests
-click==8.0.1
+click==8.1.3
     # via
     #   black
     #   flask
     #   pip-tools
-coverage==5.5
+coverage[toml]==6.4.2
     # via
     #   -r requirements.in
     #   pytest-cov
-cryptography==3.4.8
+cryptography==37.0.4
     # via paramiko
 django-dotenv==1.4.2
     # via -r requirements.in
 fabric3==1.14.post1
     # via -r requirements.in
-flake8==3.9.2
+flake8==5.0.4
     # via -r requirements.in
-flask==2.0.1
+flask==2.2.1
     # via -r requirements.in
-freezegun==1.1.0
+freezegun==1.2.1
     # via pytest-freezegun
 gunicorn==20.1.0
     # via -r requirements.in
-idna==3.2
+idna==3.3
     # via requests
+importlib-metadata==4.12.0
+    # via flask
 iniconfig==1.1.1
     # via pytest
-isort==5.9.3
+isort==5.10.1
     # via -r requirements.in
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via flask
-jinja2==3.0.1
+jinja2==3.1.2
     # via flask
-markupsafe==2.0.1
-    # via jinja2
-mccabe==0.6.1
+markupsafe==2.1.1
+    # via
+    #   jinja2
+    #   werkzeug
+mccabe==0.7.0
     # via flake8
 mypy-extensions==0.4.3
     # via black
-packaging==21.0
-    # via pytest
-paramiko==2.7.2
+packaging==21.3
+    # via
+    #   build
+    #   pytest
+paramiko==2.11.0
     # via fabric3
 pathspec==0.9.0
     # via black
-pep517==0.11.0
-    # via pip-tools
-pip-tools==6.2.0
+pep517==0.13.0
+    # via build
+pip-tools==6.8.0
     # via -r requirements.in
-platformdirs==2.3.0
+platformdirs==2.5.2
     # via black
 pluggy==1.0.0
     # via pytest
-py==1.10.0
+py==1.11.0
     # via pytest
-pycodestyle==2.7.0
+pycodestyle==2.9.1
     # via flake8
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pyflakes==2.3.1
+pyflakes==2.5.0
     # via flake8
-pynacl==1.4.0
+pynacl==1.5.0
     # via paramiko
-pyparsing==2.4.7
+pyparsing==3.0.9
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements.in
     #   pytest-cov
     #   pytest-env
     #   pytest-freezegun
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements.in
 pytest-env==0.6.2
     # via -r requirements.in
@@ -98,45 +106,40 @@ pytest-freezegun==0.4.2
     # via -r requirements.in
 python-dateutil==2.8.2
     # via freezegun
-regex==2021.8.28
-    # via black
-requests==2.26.0
+requests==2.28.1
     # via
     #   -r requirements.in
     #   slackbot
-    #   slacker
 six==1.16.0
     # via
-    #   bcrypt
     #   fabric3
-    #   pynacl
+    #   paramiko
     #   python-dateutil
-    #   slackbot
-    #   websocket-client
-slackbot==1.0.0
-    # via -r requirements.in
-slacker==0.14.0
+slack-sdk==3.18.1
     # via slackbot
-structlog==21.1.0
+slackbot @ git+https://github.com/ebmdatalab/slackbot.git@d37d27ff470c0991b70fd8cd448d2d1d3a0eda45
     # via -r requirements.in
-toml==0.10.2
-    # via
-    #   pytest
-    #   pytest-cov
-tomli==1.2.1
+structlog==22.1.0
+    # via -r requirements.in
+tomli==2.0.1
     # via
     #   black
+    #   build
+    #   coverage
     #   pep517
-typing-extensions==3.10.0.2
+    #   pytest
+typing-extensions==4.3.0
     # via black
-urllib3==1.26.6
+urllib3==1.26.11
     # via requests
-websocket-client==0.44.0
+websocket-client==1.3.3
     # via slackbot
-werkzeug==2.0.1
+werkzeug==2.2.1
     # via flask
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
+zipp==3.8.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Fixes #208 by replacing slackbot with our fork, which deals with the upcoming [changes to the slack api](https://api.slack.com/changelog/2021-10-rtm-start-to-stop)
Also upgrades other requirements.
