### PR TITLE
Set limit to max when fetching channels

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -36,7 +36,7 @@ def get_channels(client):
     return {
         channel["name"]: channel["id"]
         for channel in client.conversations_list(
-            types="public_channel,private_channel"
+            types="public_channel,private_channel", limit=1000
         )["channels"]
         if not channel["is_archived"]
     }


### PR DESCRIPTION
Make sure we get all the channels for the bot to join.  Slack's docs don't say what the default limit is, but it was returning 33 results, when we have something like 87. 