### PR TITLE
Allow users to DM the bot and improve some matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Add event subscriptions to allow the app to be notified of events in Slack/
    - message.im
    - message.mpim
    - channel_created
+   - app_mention
 3. Save changes
 
 ### Add Bot scopes
@@ -56,7 +57,8 @@ events.  We need to add some more:
    - `im:history`
    - `mpim:history`
    - `channels:read`
-2.Add the following additional scopes:
+   - `app_mentions:read`
+2. Add the following additional scopes:
    - `channels:join`
    - `users:read`
    - `groups:read`
@@ -64,6 +66,11 @@ events.  We need to add some more:
    - `im:read`
    - `reactions:write`
    - `chat:write`
+
+### Allow users to DM the app
+1. Features > App Home
+2. Under Messages Tabs, ensure the "Allow users to send Slash commands and messages from
+  the messages tab" is ticked.
 
 ### Install the app
 1. Features > OAuth & Permissions

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -69,24 +69,6 @@ raw_config = {
             },
         ],
     },
-    "bot": {
-        "python_file": "jobs.py",
-        "jobs": {
-            "join_channels": {
-                "run_args_template": "",
-                "python_function": "join_channels",
-                "report_stdout": True,
-            },
-        },
-        "slack": [
-            {
-                "command": "join channels",
-                "help": "ensure bot is in all channels",
-                "type": "schedule_job",
-                "job_type": "join_channels",
-            }
-        ]
-    },
     "fdaaa": {
         "fabfile": "https://raw.githubusercontent.com/ebmdatalab/clinicaltrials-act-tracker/master/fabfile.py",
         "jobs": {


### PR DESCRIPTION
- Updates the README instructions for letting users dm the slack app
- Updates the main job listener to listen only for `app_mention` events, not every message
- Adds a separate listener for DMs which don't require users to @ the bot
- Adds matchers to the listener decorators to remove the need for some checks on channel type etc in the code
