### PR TITLE
Update tech-support matching

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -67,7 +67,7 @@ def register_listeners(app, config, channels, bot_user_id):
     """
 
     tech_support_channel_id = channels[settings.SLACK_TECH_SUPPORT_CHANNEL]
-    tech_support_regex = re.compile(r".*tech[\s|-]support.*", flags=re.I)
+    tech_support_regex = re.compile(r".*tech-support.*", flags=re.I)
 
     @app.event(
         "app_mention",

--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -132,7 +132,11 @@ def register_listeners(app, config, channels, bot_user_id):
     @app.message(
         tech_support_regex,
         # Only match messages posted outside of the tech support channel itself
-        matchers=[lambda message: message["channel"] != tech_support_channel_id],
+        # and messages that are not posted by a bot (to avoid reposting reminders etc)
+        matchers=[
+            lambda message: message["channel"] != tech_support_channel_id,
+            lambda message: "bot_id" not in message,
+        ],
     )
     def repost_to_tech_support(message, say, ack):
         ack()

--- a/fabfile.py
+++ b/fabfile.py
@@ -32,7 +32,7 @@ def update_from_git():
         run("git clone -q git@github.com:ebmdatalab/ebmbot.git")
 
     run("git fetch --all")
-    run("git checkout --force origin/master")
+    run("git checkout --force origin/main")
 
 
 def install_requirements():

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -236,18 +236,25 @@ def test_pluralise():
 
 
 @pytest.mark.parametrize(
-    "text,channel,respost_expected",
+    "text,channel,event_kwargs,respost_expected",
     [
         # We only match the hyphenated keywords "tech-support"
-        ("This message should not match the tech support listener", "C0002", False),
+        ("This message should not match the tech support listener", "C0002", {}, False),
         # a message posted in the techsupport channel (C0001) does not repost
-        ("This message should not match the tech-support listener", "C0001", False),
-        ("This message should match the tech-support listener", "C0003", True),
-        ("This message should match the Tech-support listener", "C0002", True),
-        ("This message should match the tech-SUPPORT listener", "C0002", True),
+        ("This message should not match the tech-support listener", "C0001", {}, False),
+        # a message posted by a bot with the right keywords and channel does not repost
+        (
+            "This message should not match the tech-support listener",
+            "C0002",
+            {"bot_id": "B1"},
+            False,
+        ),
+        ("This message should match the tech-support listener", "C0003", {}, True),
+        ("This message should match the Tech-support listener", "C0002", {}, True),
+        ("This message should match the tech-SUPPORT listener", "C0002", {}, True),
     ],
 )
-def test_tech_support_listener(mock_app, text, channel, respost_expected):
+def test_tech_support_listener(mock_app, text, channel, event_kwargs, respost_expected):
     # the triggered tech support handler will first fetch the url for the message
     # and then post it to the techsupport channel
     # Before the dispatched message, neither of these paths have been called
@@ -257,7 +264,12 @@ def test_tech_support_listener(mock_app, text, channel, respost_expected):
         assert path not in recorder.mock_received_requests
 
     handle_message(
-        mock_app, text, channel=channel, reaction_count=0, event_type="message"
+        mock_app,
+        text,
+        channel=channel,
+        reaction_count=0,
+        event_type="message",
+        event_kwargs=event_kwargs or {},
     )
 
     # After the dispatched message, each path has been called once

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -238,12 +238,13 @@ def test_pluralise():
 @pytest.mark.parametrize(
     "text,channel,respost_expected",
     [
-        ("This message should match the tech support listener", "C0002", True),
+        # We only match the hyphenated keywords "tech-support"
+        ("This message should not match the tech support listener", "C0002", False),
         # a message posted in the techsupport channel (C0001) does not repost
-        ("This message should match the tech support listener", "C0001", False),
+        ("This message should not match the tech-support listener", "C0001", False),
         ("This message should match the tech-support listener", "C0003", True),
-        ("This message should match the Tech support listener", "C0002", True),
-        ("This message should match the tech SUPPORT listener", "C0002", True),
+        ("This message should match the Tech-support listener", "C0002", True),
+        ("This message should match the tech-SUPPORT listener", "C0002", True),
     ],
 )
 def test_tech_support_listener(mock_app, text, channel, respost_expected):


### PR DESCRIPTION
Limit the keywords for the tech-support listener to "tech-support" (with the hyphen).  It keeps the case-insensitive matching since something like "Tech-Support" is still likely to be a genuine call for tech-support help.

Also updates the matchers to ignore any messages from a bot, which means it won't repost reminders from Slackbot to e.g. check the tech-support rota