### PR TITLE
Pin typing-extensions to fix error in requirements file

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -16,3 +16,5 @@ pytest
 pytest-cov
 pytest-env
 pytest-freezegun
+# this is a black dependency but we include it here so that it's pinned in requirements.dev.txt
+typing-extensions

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -289,6 +289,12 @@ tomli==2.0.1 \
     #   coverage
     #   pep517
     #   pytest
+typing-extensions==4.3.0 \
+    --hash=sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02 \
+    --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
+    # via
+    #   -r requirements.dev.in
+    #   black
 virtualenv==20.16.3 \
     --hash=sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1 \
     --hash=sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9


### PR DESCRIPTION
We use pip-compile with `--require-hashes`, which requires all dependencies to be pinned.  One of black's dependencies isn't pinned, resulting in an error when we try to `pip install -r requirements.dev.txt` from scratch - I think this was only showing up after merging the latest PR because it was the first push to the new `main` branch
https://github.com/ebmdatalab/ebmbot/runs/8154622961?check_suite_focus=true