### PR TITLE
Tighten regex for tech support keyword

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -67,7 +67,11 @@ def register_listeners(app, config, channels, bot_user_id):
     """
 
     tech_support_channel_id = channels[settings.SLACK_TECH_SUPPORT_CHANNEL]
-    tech_support_regex = re.compile(r".*tech-support.*", flags=re.I)
+    # Match "tech-support" as a word (treating hyphens as word characters), except if
+    # it's preceded by a slash to avoid matching it in URLs
+    tech_support_regex = re.compile(
+        r".*(^|[^\w\-/])tech-support($|[^\w\-]).*", flags=re.I
+    )
 
     @app.event(
         "app_mention",

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -146,6 +146,10 @@ idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
     # via requests
+importlib-metadata==5.0.0 \
+    --hash=sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab \
+    --hash=sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43
+    # via flask
 itsdangerous==2.1.2 \
     --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44 \
     --hash=sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a
@@ -264,6 +268,10 @@ werkzeug==2.2.2 \
     --hash=sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f \
     --hash=sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5
     # via flask
+zipp==3.10.0 \
+    --hash=sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1 \
+    --hash=sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8
+    # via importlib-metadata
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -240,6 +240,26 @@ def test_pluralise():
     [
         # We only match the hyphenated keywords "tech-support"
         ("This message should not match the tech support listener", "C0002", {}, False),
+        # We match only distinct words
+        (
+            "This message should not match the test-tech-support listener",
+            "C0002",
+            {},
+            False,
+        ),
+        (
+            "This message should not match the tech-support-test listener",
+            "C0002",
+            {},
+            False,
+        ),
+        # We ignore mentions embeded in URLs
+        (
+            "This message should not match the /test/tech-support listener",
+            "C0002",
+            {},
+            False,
+        ),
         # a message posted in the techsupport channel (C0001) does not repost
         ("This message should not match the tech-support listener", "C0001", {}, False),
         # a message posted by a bot with the right keywords and channel does not repost
@@ -252,6 +272,11 @@ def test_pluralise():
         ("This message should match the tech-support listener", "C0003", {}, True),
         ("This message should match the Tech-support listener", "C0002", {}, True),
         ("This message should match the tech-SUPPORT listener", "C0002", {}, True),
+        ("This message should match the @tech-support listener", "C0002", {}, True),
+        ("This message should match the #tech-support listener", "C0002", {}, True),
+        ("This message should match the `tech-support` listener", "C0002", {}, True),
+        ("tech-support - this message should match", "C0002", {}, True),
+        ("This message should match - tech-support", "C0002", {}, True),
     ],
 )
 def test_tech_support_listener(mock_app, text, channel, event_kwargs, respost_expected):


### PR DESCRIPTION
Inadvertently summoning tech support is initially hilarious but thereafter quite annoying. This PR requires that the keyword be used as a distinct word, and that it not be preceded by a slash to avoid links to our documentation triggering the keyword.