### PR TITLE
Parse bot mentions in reminders correction

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -108,8 +108,12 @@ def register_listeners(app, config, channels, bot_user_id):
         _listener(event, say)
 
     def _listener(event, say):
+        # Remove the reminder prefix
         text = event["text"].replace("Reminder: ", "")
-        text = text.replace(f"<@{bot_user_id}>", "")
+        # Remove the bot mention; this sometimes includes the bot's name as well as
+        # id. In reminders, the bot mention is in the form <@AB1234|bot_name>; in user
+        # messages that @ the both, it is fjust in the form <@AB1234>. We need to match both.
+        text = re.sub(rf"<@{bot_user_id}(|.+)?>", "", text)
 
         # handle extra whitespace and punctuation
         text = " ".join(text.strip().rstrip(".").split())

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -48,6 +48,14 @@ def test_schedule_job(mock_app):
     assert_job_matches(jj[0], "test_good_job", {"n": "10"}, "channel", T(60), None)
 
 
+def test_schedule_job_from_reminder(mock_app):
+    handle_message(mock_app, "Reminder: <@U1234|test bot> test do job 10")
+
+    jj = scheduler.get_jobs_of_type("test_good_job")
+    assert len(jj) == 1
+    assert_job_matches(jj[0], "test_good_job", {"n": "10"}, "channel", T(60), None)
+
+
 def test_schedule_python_job(mock_app):
     handle_message(mock_app, "<@U1234> test do python job")
 


### PR DESCRIPTION
Reminders that @ the bot use its username as well as its ID

We need to replace this too so that bot commands in reminders will work