### PR TITLE
Fix team report bug

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -83,7 +83,7 @@ class JobDispatcher:
         self.notify_start()
         rc = self.run_command()
         scheduler.mark_job_done(self.job["id"])
-        self.notifiy_end(rc)
+        self.notify_end(rc)
 
     def run_command(self):
         """Run the command, writing stdout/stderr to separate files."""
@@ -146,7 +146,7 @@ class JobDispatcher:
         msg = f"Command `{self.job['type']}` about to start"
         notify_slack(self.slack_client, settings.SLACK_LOGS_CHANNEL, msg)
 
-    def notifiy_end(self, rc):
+    def notify_end(self, rc):
         """Send notification that command has ended, reporting stdout if
         required."""
 
@@ -167,7 +167,7 @@ class JobDispatcher:
             self.slack_client,
             self.job["channel"],
             msg,
-            message_format=self.job_config["report_format"],
+            message_format=self.job_config["report_format"] if rc == 0 else "text",
         )
 
     def set_up_cwd(self):

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -26,12 +26,18 @@ def assert_subdict(d1, d2):
         assert d1[k] == d2[k]
 
 
-def assert_slack_client_sends_messages(test_recorder, messages_kwargs=None):
+def assert_slack_client_sends_messages(
+    test_recorder, messages_kwargs=None, message_format=None
+):
     messages_kwargs = messages_kwargs or []
+    message_format = message_format or "text"
     actual_call_kwargs = test_recorder.mock_received_requests_kwargs.get(
         "/chat.postMessage", []
     )
     check_slack_client_calls(actual_call_kwargs, messages_kwargs)
+    # check the format of the final message sent to slack
+    if message_format == "text" and messages_kwargs:
+        assert "blocks" not in actual_call_kwargs[-1]
 
 
 @contextmanager

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -56,6 +56,12 @@ raw_config = {
                 "report_stdout": True,
                 "report_format": "blocks"
             },
+            "bad_python_job_with_blocks": {
+                "run_args_template": "",
+                "python_function": "hello_world_blocks_error",
+                "report_stdout": True,
+                "report_format": "blocks"
+            },
         },
         "slack": [
             {

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -293,12 +293,38 @@ def test_python_job_success_with_blocks(mock_client):
                 "blocks": expected_blocks,
             },
         ],
+        message_format="blocks",
     )
     with open(os.path.join(log_dir, "stdout")) as f:
         assert json.load(f) == expected_blocks
 
     with open(os.path.join(log_dir, "stderr")) as f:
         assert f.read() == ""
+
+
+def test_python_job_failure_with_blocks(mock_client):
+    log_dir = build_log_dir("test_bad_python_job_with_blocks")
+
+    scheduler.schedule_job("test_bad_python_job_with_blocks", {}, "channel", TS, 0)
+    job = scheduler.reserve_job()
+
+    do_job(mock_client.client, job)
+
+    assert_slack_client_sends_messages(
+        mock_client.recorder,
+        messages_kwargs=[
+            {"channel": "logs", "text": "about to start"},
+            {"channel": "channel", "text": "failed"},
+        ],
+    )
+
+    with open(os.path.join(log_dir, "stdout")) as f:
+        assert f.read() == ""
+
+    with open(os.path.join(log_dir, "stderr")) as f:
+        stderr = f.read()
+        assert "Traceback (most recent call last):" in stderr
+        assert "An error was found!" in stderr
 
 
 def test_python_job_failure(mock_client):

--- a/tests/workspace/test/jobs.py
+++ b/tests/workspace/test/jobs.py
@@ -12,3 +12,7 @@ def hello_world_blocks():
     return json.dumps(
         [{"type": "section", "text": {"type": "plain_text", "text": "Hello World!"}}]
     )
+
+
+def hello_world_blocks_error():
+    raise Exception("An error was found!")

--- a/tests/workspace/test_generate_report.py
+++ b/tests/workspace/test_generate_report.py
@@ -10,6 +10,77 @@ def test_generate_report():
                 "organization": {"projectV2": {"id": 1}},
                 "node": {
                     "items": {
+                        "nodes": [
+                            {
+                                "content": {
+                                    "title": "Card 1",
+                                    "bodyUrl": "http://card1",
+                                    "assignees": {"nodes": []},
+                                },
+                                "fieldValues": {"nodes": [{"name": "Under Review"}]},
+                            },
+                            {
+                                "content": {
+                                    "title": "Card 2",
+                                    "assignees": {"nodes": []},
+                                },
+                                "fieldValues": {"nodes": [{"name": "In Progress"}]},
+                            },
+                            {
+                                "content": {
+                                    "title": "Card 3",
+                                    "assignees": {"nodes": []},
+                                },
+                                "fieldValues": {"nodes": [{"name": "Blocked"}]},
+                            },
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
+                    }
+                },
+            }
+        }
+
+    generate_report.post_request = mock_post_request
+    response = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":newspaper: Project Board Summary :newspaper:",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://github.com/orgs/opensafely-core/projects/13/views/1|View board>",
+            },
+        },
+        {"type": "divider"},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "*Under Review*"}},
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "\u2022 <http://card1|Card 1>\n"},
+        },
+        {"type": "divider"},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "*Blocked*"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "\u2022 Card 3\n"}},
+        {"type": "divider"},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "*In Progress*"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "\u2022 Card 2\n"}},
+    ]
+
+    statuses = ["Under Review", "Blocked", "In Progress"]
+    assert generate_report.main(13, statuses) == json.dumps(response)
+
+
+def test_generate_report_no_issues():
+    def mock_post_request(payload):
+        return {
+            "data": {
+                "organization": {"projectV2": {"id": 1}},
+                "node": {
+                    "items": {
                         "nodes": "",
                         "pageInfo": {"hasNextPage": False, "endCursor": "abc"},
                     }
@@ -33,33 +104,6 @@ def test_generate_report():
                 "type": "mrkdwn",
                 "text": "<https://github.com/orgs/opensafely-core/projects/13/views/1|View board>",
             },
-        },
-        {"type": "divider"},
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "*Under Review*"},
-        },
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": ""},
-        },
-        {"type": "divider"},
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "*Blocked*"},
-        },
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": ""},
-        },
-        {"type": "divider"},
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": "*In Progress*"},
-        },
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": ""},
         },
     ]
 

--- a/workspace/generate_report.py
+++ b/workspace/generate_report.py
@@ -50,20 +50,21 @@ def main(project_num, statuses):
     ]
 
     for status, tickets in tickets_by_status.items():
-        ticket_list = "".join(f"• {ticket}\n" for ticket in tickets)
-        report_output.extend(
-            [
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*{status}*"},
-                },
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": ticket_list},
-                },
-            ]
-        )
+        if tickets:
+            ticket_list = "".join(f"• {ticket}\n" for ticket in tickets)
+            report_output.extend(
+                [
+                    {"type": "divider"},
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*{status}*"},
+                    },
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": ticket_list},
+                    },
+                ]
+            )
 
     return json.dumps(report_output)
 


### PR DESCRIPTION
The data team report failed this morning (with a Slack "invalid blocks" error) because there were no tickets in one of the statuses it was trying to report on.  This fixes that bug, and also another with actually reporting the job failure to slack. 