### PR TITLE
Call tech-support for failed commands

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -162,7 +162,7 @@ class JobDispatcher:
             else:
                 return
         else:
-            msg = f"Command `{self.job['type']}` failed (find logs in {self.log_dir})"
+            msg = f"Command `{self.job['type']}` failed (find logs in {self.log_dir}). Calling tech-support."
         notify_slack(
             self.slack_client,
             self.job["channel"],


### PR DESCRIPTION
This ensures that if a failed command posts in #tech-noise, we'll notify tech support about it so someone can investigate.