### PR TITLE
Repost messages for failed commands to tech support channel

### DIFF
--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -12,4 +12,7 @@ def notify_slack(
     logger.info(
         "Sending message", channel=channel, message=message_text, thread_ts=thread_ts
     )
-    slack_client.chat_postMessage(channel=channel, thread_ts=thread_ts, **msg_kwargs)
+    resp = slack_client.chat_postMessage(
+        channel=channel, thread_ts=thread_ts, **msg_kwargs
+    )
+    return resp.data

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -150,7 +150,9 @@ class MockHandler(SimpleHTTPRequestHandler):
         "/chat.getPermalink": json.dumps(
             {"ok": True, "permalink": "http://test"}
         ).encode("utf-8"),
-        "/chat.postMessage": json.dumps({"ok": True}).encode("utf-8"),
+        "/chat.postMessage": json.dumps(
+            {"ok": True, "channel": "C0002", "ts": 1234.0}
+        ).encode("utf-8"),
         "/reactions.add": json.dumps({"ok": True}).encode("utf-8"),
     }
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-from unittest.mock import Mock
 
 import pytest
 
@@ -25,10 +24,10 @@ def remove_logs_dir():
     shutil.rmtree(settings.LOGS_DIR, ignore_errors=True)
 
 
-def test_run_once():
+def test_run_once(mock_client):
     # Because this mock gets used in a subprocess (I think) we can't actually
     # get any information out of it about how it was used.
-    slack_client = Mock()
+    slack_client = mock_client.client
 
     scheduler.schedule_suppression("test_good_job", T(-15), T(-5))
     scheduler.schedule_suppression("test_bad_job", T(-15), T(-5))
@@ -167,6 +166,8 @@ def test_job_failure(mock_client):
         messages_kwargs=[
             {"channel": "logs", "text": "about to start"},
             {"channel": "channel", "text": "failed"},
+            # failed message url reposted to tech support channel (C0001 in the mock)
+            {"channel": "C0001", "text": "http://test"},
         ],
     )
 
@@ -189,6 +190,8 @@ def test_job_failure_when_command_not_found(mock_client):
         messages_kwargs=[
             {"channel": "logs", "text": "about to start"},
             {"channel": "channel", "text": "failed"},
+            # failed message url reposted to tech support channel (C0001 in the mock)
+            {"channel": "C0001", "text": "http://test"},
         ],
     )
 
@@ -315,6 +318,8 @@ def test_python_job_failure_with_blocks(mock_client):
         messages_kwargs=[
             {"channel": "logs", "text": "about to start"},
             {"channel": "channel", "text": "failed"},
+            # failed message url reposted to tech support channel (C0001 in the mock)
+            {"channel": "C0001", "text": "http://test"},
         ],
     )
 
@@ -338,6 +343,8 @@ def test_python_job_failure(mock_client):
         messages_kwargs=[
             {"channel": "logs", "text": "about to start"},
             {"channel": "channel", "text": "failed"},
+            # failed message url reposted to tech support channel (C0001 in the mock)
+            {"channel": "C0001", "text": "http://test"},
         ],
     )
 


### PR DESCRIPTION
The bot doesn't register messages that it posts itself (for obvious reasons, when you think about it), so
just tagging tech-support in the message won't work. We now repost into the tech-support channel when a failed message is encountered.