### PR TITLE
Add a WRITEABLE_DIR setting for jobs that need to write files

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -161,10 +161,9 @@ for error reporting
 The path for the sqlite db file; set this to a file in the dokku mounted storage
 - `DB_PATH`
 
-The path for workspaces that are created by the job (i.e. fabric jobs that fetch
-the fabfile for running the commands). Set this to a directory in the dokku mounted
-storage that the docker user will have write access to.
-- `FAB_WORKSPACE_DIR`
+A path to a directory that jobs can write files to. Set this to a directory in the
+dokku mounted storage that the docker user will have write access to.
+- `WRITEABLE_DIR`
 
 Path for file created after bot startup (used in the bot healthcheck in `app.json`).
 - `BOT_CHECK_FILE`

--- a/ebmbot/settings.py
+++ b/ebmbot/settings.py
@@ -8,15 +8,21 @@ env.read_env()
 
 APPLICATION_ROOT = Path(__file__).resolve().parent.parent
 
-DB_PATH = env.path("DB_PATH", default=APPLICATION_ROOT / "ebmbot.db")
+# A directory that jobs can write to; in production, this is a volume
+# that is mounted into the dokku app and is owned by the non-root docker user
+WRITEABLE_DIR = env.path("WRITEABLE_DIR", default=APPLICATION_ROOT)
+
+DB_PATH = env.path("DB_PATH", default=WRITEABLE_DIR / "ebmbot.db")
+
 # location of job workspaces that live in this repo
 WORKSPACE_DIR = env.path("WORKSPACE_DIR", default=APPLICATION_ROOT / "workspace")
+
 # location of fabric jobs which don't have workspaces in this repo
 # These jobs will fetch fabric files and create a folder in
 # FAB_WORKSPACE_DIR. In production, we want this to be a location in a
 # mounted volume in the dokku app, which the docker user has write access
 # to, and not a location that only exists in the container
-FAB_WORKSPACE_DIR = env.path("FAB_WORKSPACE_DIR", default=WORKSPACE_DIR)
+FAB_WORKSPACE_DIR = env.path("FAB_WORKSPACE_DIR", default=WRITEABLE_DIR / "workspace")
 LOGS_DIR = env.path("LOGS_DIR")
 # An alias for logs dir; this is just used for reporting the host location of logs
 # in slack, where the log dir is a mounted volume

--- a/workspace/techsupport/jobs.py
+++ b/workspace/techsupport/jobs.py
@@ -1,6 +1,5 @@
 import json
 from datetime import date, datetime, timedelta
-from pathlib import Path
 
 from apiclient import discovery
 from google.oauth2 import service_account
@@ -9,7 +8,7 @@ from ebmbot import settings
 
 
 def config_file():
-    return Path(__file__).parent / "ooo.json"
+    return settings.WRITEABLE_DIR / "techsupport_ooo.json"
 
 
 def today():


### PR DESCRIPTION
This makes a more general use writeable dir setting, for any jobs that need to write files. Currently, in addition to fabric jobs, we have the tech support ooo job that writes the OOO status to a file.