### PR TITLE
Catch slack errors and add a command to remove jobs

### DIFF
--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -1,8 +1,10 @@
+from time import sleep
+
 from .logger import logger
 
 
 def notify_slack(
-    slack_client, channel, message_text, thread_ts=None, message_format=None
+    slack_client, channel, message_text, thread_ts=None, message_format=None, fail=False
 ):
     """Send message to Slack."""
     msg_kwargs = {"text": str(message_text)}
@@ -12,7 +14,24 @@ def notify_slack(
     logger.info(
         "Sending message", channel=channel, message=message_text, thread_ts=thread_ts
     )
-    resp = slack_client.chat_postMessage(
-        channel=channel, thread_ts=thread_ts, **msg_kwargs
+    # In case of any unexpected transient exception posting to slack, retry up to 3
+    # times and then log the error, to avoid errors in scheduled jobs.
+    attempts = 0
+    while attempts < 3:
+        try:
+            resp = slack_client.chat_postMessage(
+                channel=channel, thread_ts=thread_ts, **msg_kwargs
+            )
+            return resp.data
+        except Exception as err:
+            attempts += 1
+            sleep(1)
+            error = err
+
+    logger.error(
+        "Could not notify slack",
+        channel=channel,
+        message=message_text,
+        thread_ts=thread_ts,
+        error=error,
     )
-    return resp.data

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -474,6 +474,32 @@ def test_new_channel_created(mock_app):
     ] == {"channel": "C0NEW", "users": "U1234"}
 
 
+def test_remove_job(mock_app):
+    recorder = mock_app.recorder
+    handle_message(mock_app, "<@U1234> test do job 10", reaction_count=1)
+    jobs = scheduler.get_jobs_of_type("test_good_job")
+    assert len(jobs) == 1
+    job_id = jobs[0]["id"]
+    handle_message(mock_app, f"<@U1234> remove job id {job_id}", reaction_count=2)
+    assert not scheduler.get_jobs_of_type("test_good_job")
+
+    post_message = recorder.mock_received_requests_kwargs["/chat.postMessage"][0]
+    assert (
+        "text",
+        "Job id [1] removed",
+    ) in post_message.items()
+
+
+def test_remove_non_existent_job(mock_app):
+    recorder = mock_app.recorder
+    handle_message(mock_app, "<@U1234> remove job id 10", reaction_count=1)
+    post_message = recorder.mock_received_requests_kwargs["/chat.postMessage"][0]
+    assert (
+        "text",
+        "Job id [10] not found in running or scheduled jobs",
+    ) in post_message.items()
+
+
 def handle_message(
     mock_app,
     text,

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -153,6 +153,26 @@ def test_job_success_with_no_report(mock_client):
         assert f.read() == ""
 
 
+def test_job_success_with_slack_exception(mock_client_with_slack_exception):
+    # Test that the job still succeeds even if notifying slack errors
+    log_dir = build_log_dir("test_good_job")
+
+    scheduler.schedule_job("test_good_job", {}, "channel", TS, 0)
+    job = scheduler.reserve_job()
+
+    do_job(mock_client_with_slack_exception.client, job)
+    assert_slack_client_sends_messages(
+        mock_client_with_slack_exception.recorder,
+        messages_kwargs=[],
+    )
+
+    with open(os.path.join(log_dir, "stdout")) as f:
+        assert f.read() == "the owl and the pussycat\n"
+
+    with open(os.path.join(log_dir, "stderr")) as f:
+        assert f.read() == ""
+
+
 def test_job_failure(mock_client):
     log_dir = build_log_dir("test_bad_job")
 


### PR DESCRIPTION
On Friday Rich tried to run an op command, but nothing happened
https://bennettoxford.slack.com/archives/CGF9TKZLG/p1704475634495869

`@BennettBot status` suggested that [this request](https://bennettoxford.slack.com/archives/CGF9TKZLG/p1704192282113689) to run a measures preview from 2nd Jan was still running, so the new request was just scheduled. Something apparently happened that meant the job didn't report that it either failed or succeeded, but I can't see far enough back in the old logs to see if anything was logged. In any case, the "running" job blocked any attempts to retry it, so this PR adds a command to remove a job by id in case this happens again.

Although I can't see if it was the case for the 2nd Jan job, there was an instance of an uncaught error from slack 
```
ERROR:slack_bolt.App:on_error invoked (session id: xxxxxx, error: BlockingIOError, message: [Errno 11] Resource temporarily unavailable)
```
This seems to be an occasional transient thing, but if we happen to encounter it when notifying slack of starting or completing a job, we don't want it to prevent the job from being marked as complete, so now it retries up to 3 times and then logs the error. 