### PR TITLE
Run webserver with gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 bot: python -m ebmbot.bot
 dispatcher: python -m ebmbot.dispatcher
-web: python -m ebmbot.webserver
+web: gunicorn --config /app/gunicorn/conf.py ebmbot.webserver:app
 release: rm -f /storage/.bot_startup_check

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
     extends:
       service: dev
     container_name: bennettbot-webserver
-    command: python -m ebmbot.webserver
+    command: gunicorn --config /app/gunicorn/conf.py ebmbot.webserver:app
     # host:container ports: container port should match the port in WEBHOOK_ORIGIN
     ports:
       - "1234:1234"

--- a/ebmbot/webserver/__main__.py
+++ b/ebmbot/webserver/__main__.py
@@ -5,6 +5,7 @@ from ..logger import logger
 from . import app
 
 
-logger.info("running ebmbot.webserver")
-port = urlparse(settings.WEBHOOK_ORIGIN).port
-app.run(host="0.0.0.0", port=port, load_dotenv=False, debug=False)
+if __name__ == "__main__":
+    logger.info("running ebmbot.webserver")
+    port = urlparse(settings.WEBHOOK_ORIGIN).port
+    app.run(host="0.0.0.0", port=port, load_dotenv=False, debug=False)

--- a/gunicorn/conf.py
+++ b/gunicorn/conf.py
@@ -1,0 +1,17 @@
+from urllib.parse import urlparse
+
+from ebmbot import settings
+from ebmbot.logger import logger
+
+
+logger.info("running ebmbot.webserver")
+port = urlparse(settings.WEBHOOK_ORIGIN).port
+
+bind = f"0.0.0.0:{port}"
+
+workers = 8
+timeout = 120
+
+# Where to log to (stdout and stderr)
+accesslog = "-"
+errorlog = "-"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ extend-ignore = [
 [tool.ruff.isort]
 lines-after-imports = 2
 
+[tool.ruff.per-file-ignores]
+"gunicorn/conf.py" = ["INP001"]
+
 [tool.pytest.ini_options]
 env = [
     "DB_PATH=tests/ebmbot.db",


### PR DESCRIPTION
The webserver in BennettBot is a Flask app; as per flask [docs](https://flask.palletsprojects.com/en/3.0.x/tutorial/deploy/#run-with-a-production-server) using app.run is intended for development only. As we've now moved to the new dokku app, update to run with gunicorn as well.