### PR TITLE
More useful help and error messages

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -170,7 +170,7 @@ def register_listeners(app, config, channels, bot_user_id):
                     return
 
         include_apology = text != "help"
-        handle_help(event, say, config["help"], include_apology)
+        handle_help(event, say, config["help"], config["description"], include_apology)
 
     @app.message(
         tech_support_regex,
@@ -414,7 +414,6 @@ def handle_cancel_suppression(message, say, slack_config):
 @log_call
 def handle_namespace_help(message, say, help_config):
     """Report commands available in namespace."""
-
     lines = ["The following commands are available:", ""]
 
     for command, help_ in help_config:
@@ -424,17 +423,20 @@ def handle_namespace_help(message, say, help_config):
 
 
 @log_call
-def handle_help(message, say, help_configs, include_apology):
+def handle_help(message, say, help_configs, description_configs, include_apology):
     """Report all available namespaces."""
 
     if include_apology:
         lines = ["I'm sorry, I didn't understand you", ""]
     else:
         lines = []
-    lines.extend(["Commands in the following namespaces are available:", ""])
+    lines.extend(["Commands in the following categories are available:", ""])
 
     for namespace in sorted(help_configs):
-        lines.append(f"* `{namespace}`")
+        namespace_line = f"* `{namespace}`"
+        if description_configs[namespace]:
+            namespace_line += f": {description_configs[namespace]}"
+        lines.append(namespace_line)
 
     if message["type"] == "app_mention":
         prefix = f"@{settings.SLACK_APP_USERNAME} "
@@ -442,7 +444,7 @@ def handle_help(message, say, help_configs, include_apology):
         prefix = ""
 
     lines.append(
-        f"Enter `{prefix}[namespace] help` (eg `{prefix}{random.choice(list(help_configs))} help`) for more help"
+        f"Enter `{prefix}[category] help` (e.g. `{prefix}{random.choice(list(help_configs))} help`) for more help"
     )
     lines.append(f"Enter `{prefix}status` to see running and scheduled jobs")
     lines.append(

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -10,6 +10,7 @@ from ebmbot import settings
 # fmt: off
 raw_config = {
     "test": {
+        "description": "Some commands to test things work",
         "jobs": {
             "read_poem": {
                 "run_args_template": "cat poem",
@@ -47,6 +48,7 @@ raw_config = {
         ],
     },
     "fdaaa": {
+        "description": "Trials Tracker (https://fdaaa.trialstracker.net)",
         "fabfile": "https://raw.githubusercontent.com/ebmdatalab/clinicaltrials-act-tracker/master/fabfile.py",
         "jobs": {
             "deploy": {
@@ -63,6 +65,7 @@ raw_config = {
         ],
     },
     "op": {
+        "description": "OpenPrescribing deployment and tools",
         "fabfile": "https://raw.githubusercontent.com/ebmdatalab/openprescribing/main/fabfile.py",
         "jobs": {
             "deploy": {
@@ -186,6 +189,7 @@ raw_config = {
         }],
     },
     "outputchecking": {
+        "description": "Output Checking tools",
         "jobs": {
             "rota_report": {
                 "run_args_template": "python jobs.py",
@@ -203,6 +207,7 @@ raw_config = {
         ],
     },
     "report": {
+        "description": "Run GitHub Project board reports",
         "jobs": {
             "run_report": {
                 "run_args_template": "python generate_report.py --project-num {project_number} --statuses {statuses}",
@@ -242,6 +247,7 @@ raw_config = {
         ]
     },
     "techsupport": {
+        "description": "Tech Support out of office and rota",
         "jobs": {
             "out_of_office_on": {
                 "run_args_template": "python jobs.py on {start_date} {end_date}",
@@ -290,6 +296,7 @@ raw_config = {
         ],
     },
     "funding": {
+        "description": "Run funding reports",
         "jobs": {
             "generate_report": {
                 "run_args_template": "python funding_report.py",
@@ -319,6 +326,7 @@ def build_config(raw_config):
     config = {
         "jobs": {},
         "slack": [],
+        "description": {},
         "help": {},
         "fabfiles": {},
         "workspace_dir": {},
@@ -327,6 +335,8 @@ def build_config(raw_config):
     for namespace in raw_config:
         if "_" in namespace:  # pragma: no cover
             raise RuntimeError("Namespaces must not contain underscores")
+
+        config["description"][namespace] = raw_config[namespace].get("description", "")
 
         helps = []
 

--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -4,7 +4,7 @@ from .logger import logger
 
 
 def notify_slack(
-    slack_client, channel, message_text, thread_ts=None, message_format=None, fail=False
+    slack_client, channel, message_text, thread_ts=None, message_format=None
 ):
     """Send message to Slack."""
     msg_kwargs = {"text": str(message_text)}

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -115,6 +115,7 @@ raw_config = {
         ],
     },
     "test1": {
+        "description": "Test description",
         "jobs": {
             "good_job": {
                 "run_args_template": "cat poem",

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -137,15 +137,22 @@ def test_namespace_help(mock_app):
 
 def test_help(mock_app):
     handle_message(mock_app, "<@U1234> help", reaction_count=0)
-    assert_slack_client_sends_messages(
-        mock_app.recorder, messages_kwargs=[{"channel": "channel", "text": "* `test`"}]
-    )
+    for msg_fragment in [
+        "Commands in the following categories are available",
+        "* `test`",
+        "* `test1`: Test description",
+    ]:
+        assert_slack_client_sends_messages(
+            mock_app.recorder,
+            messages_kwargs=[
+                {"channel": "channel", "text": msg_fragment},
+            ],
+        )
 
 
 def test_not_understood(mock_app):
     handle_message(mock_app, "<@U1234> beep boop", reaction_count=0)
-
-    for expected_fragment in ["I'm sorry", "Enter `@test_username [namespace] help`"]:
+    for expected_fragment in ["I'm sorry", "Enter `@test_username [category] help`"]:
         assert_slack_client_sends_messages(
             mock_app.recorder,
             messages_kwargs=[{"channel": "channel", "text": expected_fragment}],
@@ -161,7 +168,7 @@ def test_not_understood_direct_message(mock_app):
         event_type="message",
         event_kwargs={"channel_type": "im"},
     )
-    for expected_fragment in ["I'm sorry", "Enter `[namespace] help`"]:
+    for expected_fragment in ["I'm sorry", "Enter `[category] help`"]:
         assert_slack_client_sends_messages(
             mock_app.recorder,
             messages_kwargs=[{"channel": "IM0001", "text": expected_fragment}],

--- a/tests/test_job_configs.py
+++ b/tests/test_job_configs.py
@@ -9,6 +9,7 @@ from ebmbot.job_configs import build_config
 def test_build_config():
     raw_config = {
         "ns1": {
+            "description": "ns1 jobs",
             "jobs": {
                 "good_job": {"run_args_template": "cat [poem]"},
                 "bad_job": {"run_args_template": "dog [poem]"},
@@ -144,6 +145,12 @@ def test_build_config():
                 "delay_seconds": 0,
             },
         ],
+        "description": {
+            "ns1": "ns1 jobs",
+            "ns2": "",
+            "ns3": "",
+            "test": "",
+        },
         "help": {
             "ns1": [["ns1 read poem [poem]", "read a poem"]],
             "ns2": [["ns2 read poem [poem]", "read a poem"]],


### PR DESCRIPTION
Some extra user help that came out of my show-and-tell:

- add a description to each category of available slack commands to display in the main `@BennettBot help`
- Label namespaces "categories" in the help message (Fixes #34)
- Post helpful error messages back to slack if an unexpected error is caught by the error handler 