### PR TITLE
Add commands to show head/tail of error log files for failed bot commands

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -141,7 +141,14 @@ class JobDispatcher:
             else:
                 return
         else:
-            msg = f"Command `{self.job['type']}` failed (find logs in {self.host_log_dir} on dokku3). Calling tech-support."
+            msg = (
+                f"Command `{self.job['type']}` failed.\n"
+                f"Find logs in {self.host_log_dir} on dokku3."
+                f"Or check logs here with\n"
+                f"* `@{settings.SLACK_APP_USERNAME} errorlogs tail {self.host_log_dir}`\n"
+                f"* `@{settings.SLACK_APP_USERNAME} errorlogs head {self.host_log_dir}`\n"
+                "Calling tech-support."
+            )
             error = True
 
         slack_message = notify_slack(

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -22,6 +22,9 @@ raw_config = {
             "hello_name": {
                 "run_args_template": "python jobs.py --name={name}",
                 "report_stdout": True,
+            },
+            "bad_job": {
+                "run_args_template": "unknown command",
             }
         },
         "slack": [
@@ -43,6 +46,12 @@ raw_config = {
                 "help": "say hello",
                 "action": "schedule_job",
                 "job_type": "hello_world",
+            },
+            {
+                "command": "bad job",
+                "help": "a job that always errors",
+                "action": "schedule_job",
+                "job_type": "bad_job",
             },
         ],
     },
@@ -306,6 +315,32 @@ raw_config = {
             },
         ],
     },
+    "errorlogs": {
+        "jobs": {
+            "tail": {
+                "run_args_template": "/bin/bash show.sh -t {logdir}",
+                "report_stdout": True,
+            },
+            "head": {
+                "run_args_template": "/bin/bash show.sh -h {logdir}",
+                "report_stdout": True,
+            },
+        },
+        "slack": [
+            {
+                "command": "tail [logdir]",
+                "help": "Show tail of an error file located in [logdir] (a path to a log directory as reported by a failed job)",
+                "action": "schedule_job",
+                "job_type": "tail",
+            },
+            {
+                "command": "head [logdir]",
+                "help": "Show head of an error file located in a [logdir] (a path to a log directory as reported by a failed job)",
+                "action": "schedule_job",
+                "job_type": "head",
+            },
+        ],
+    }
 }
 # fmt: on
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -207,7 +207,7 @@ def test_job_failure_when_command_not_found(mock_client):
         mock_client.recorder,
         messages_kwargs=[
             {"channel": "logs", "text": "about to start"},
-            {"channel": "channel", "text": "failed (find logs in tests/logs/"},
+            {"channel": "channel", "text": f"failed.\nFind logs in {log_dir}"},
             # failed message url reposted to tech support channel (C0001 in the mock)
             {"channel": "C0001", "text": "http://test"},
         ],
@@ -227,11 +227,12 @@ def test_job_failure_with_host_log_dirs_setting(mock_client):
     scheduler.schedule_job("test_bad_job", {}, "channel", TS, 0)
     job = scheduler.reserve_job()
     do_job(mock_client.client, job)
+
     assert_slack_client_sends_messages(
         mock_client.recorder,
         messages_kwargs=[
             {"channel": "logs", "text": "about to start"},
-            {"channel": "channel", "text": "failed (find logs in /host/logs/"},
+            {"channel": "channel", "text": "failed.\nFind logs in /host/logs/"},
             # failed message url reposted to tech support channel (C0001 in the mock)
             {"channel": "C0001", "text": "http://test"},
         ],

--- a/tests/test_errorlogs.py
+++ b/tests/test_errorlogs.py
@@ -1,0 +1,80 @@
+import subprocess
+from os import environ
+from pathlib import Path
+
+import pytest
+
+from ebmbot import settings
+
+from .test_dispatcher import build_log_dir
+
+
+def setup_failed_logs():
+    log_dir = Path(build_log_dir("err_bad_job"))
+    log_dir.mkdir(exist_ok=True, parents=True)
+    with open(Path(log_dir) / "stderr", "w") as f:
+        f.write("foo")
+    return log_dir
+
+
+@pytest.mark.parametrize(
+    "option,expected_output",
+    [
+        ("-h", b"Reading head of error log"),
+        ("-t", b"Reading tail of error log"),
+        ("-g", b"Invalid option"),
+    ],
+)
+def test_errorlogs(option, expected_output):
+    log_dir = setup_failed_logs()
+    errorlogs_workspace = Path(__file__).parent.parent / "workspace" / "errorlogs"
+
+    rv = subprocess.run(
+        f"/bin/bash show.sh {option} {log_dir.resolve()}",
+        cwd=errorlogs_workspace,
+        env={**environ, "PYTHONPATH": errorlogs_workspace.parent},
+        shell=True,
+        capture_output=True,
+    )
+    assert expected_output in rv.stdout
+
+
+def test_errorlogs_with_different_host_logs_dir():
+    log_dir = setup_failed_logs()
+    errorlogs_workspace = Path(__file__).parent.parent / "workspace" / "errorlogs"
+
+    # Log files are located at LOGS_DIR (in prod, a path to the logs folder in the
+    # mounted volume). This is aliased to HOST_LOGS_DIR in slack messages, so that
+    # failed commands tell users where to find logs on the host filesystem
+    # So if a user calls the command with the host location, it needs to
+    # look for the file in the real LOGS_DIR location
+    dummy_host_logs = "/hosts/dummy_logs"
+    host_log_dir = str(log_dir).replace(str(settings.LOGS_DIR), dummy_host_logs)
+
+    rv = subprocess.run(
+        f"/bin/bash show.sh -h {host_log_dir}",
+        cwd=errorlogs_workspace,
+        env={
+            **environ,
+            "PYTHONPATH": errorlogs_workspace.parent,
+            "LOGS_DIR": settings.LOGS_DIR.resolve(),
+            "HOST_LOGS_DIR": dummy_host_logs,
+        },
+        shell=True,
+        capture_output=True,
+    )
+    assert b"Reading head of error log" in rv.stdout
+
+
+def test_errorlogs_file_not_found():
+    log_dir = setup_failed_logs()
+    errorlogs_workspace = Path(__file__).parent.parent / "workspace" / "errorlogs"
+
+    rv = subprocess.run(
+        f"/bin/bash show.sh -h {log_dir / 'unk'}",
+        cwd=errorlogs_workspace,
+        env={**environ, "PYTHONPATH": errorlogs_workspace.parent},
+        shell=True,
+        capture_output=True,
+    )
+    assert b"not found" in rv.stdout

--- a/workspace/errorlogs/show.sh
+++ b/workspace/errorlogs/show.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+while getopts "ht" option; do
+    case $option in
+        h)
+          command="head"
+          ;;
+        t)
+          command="tail"
+          ;;
+        \?) # Invalid option
+            echo "Error: Invalid option"
+            exit;;
+    esac
+  done
+
+shift
+logdir=$1
+host_dir=${HOST_LOGS_DIR:-$LOGS_DIR}
+
+logfile="$(echo "$logdir" | sed "s|$host_dir|$LOGS_DIR|g")/stderr"
+if test -f "$logfile"; then
+  echo "Reading $command of error log: $logdir/stderr"
+  echo "------------------------------"
+  if [[ "$command" == "head" ]]; then
+    head "$logfile"
+  else
+    tail "$logfile"
+  fi
+else
+  echo "ERROR: $logdir/stderr not found"
+fi


### PR DESCRIPTION
When a bot command fails, it returns a message that says where the logs can be found, but it's quite tedious to ssh to dokku3 in order to check what went wrong. This adds two new commands `errorlog head /path/to/log/dir` and `errorlog tail /path/to/log/dir` that let us check the error logs from slack.

It's slightly more complicated than just a `head`/`tail` on the log file, because we need the bot to read from the log folder in its mounted storage volume rather than the location in the host filesystem. 