### PR TITLE
Add the docker user's ssh key with ssh-add

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -211,7 +211,7 @@ docker push ghcr.io/ebmdatalab/bennettbot:latest
 SHA=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ebmdatalab/bennettbot:latest)
 ```
 
-On dokku3, as the `dokku` user:
+On dokku3:
 ```
 $ dokku git:from-image bennettbot <SHA>
 ```

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 bot: python -m ebmbot.bot
-dispatcher: python -m ebmbot.dispatcher
+dispatcher: sh -c 'eval `ssh-agent` && ssh-add ~/.ssh/id_ed25519 && python -m ebmbot.dispatcher'
 web: gunicorn --config /app/gunicorn/conf.py ebmbot.webserver:app
 release: rm -f /storage/.bot_startup_check


### PR DESCRIPTION
This wasn't needed with fabric3, but now we've replaced it with fab-classic (and paramiko with paramiko-ng), the ssh key in the mounted ebmbot user's home directory wasn't being recognised and it hung asking for a password. It needs to be explicitly added with ssh-add. I'm not sure the Procfile is the place I really want to do it, but it's the only way I found that worked. The "release" command is run before containers are deployed, and a post-deploy command in app.json also doesn't run in the containers afaict.

(I did also try explicitly telling fabric which key file to use with the `-i` option, to no avail. 