### PR TITLE
Add an option to show whole error log

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -144,9 +144,8 @@ class JobDispatcher:
             msg = (
                 f"Command `{self.job['type']}` failed.\n"
                 f"Find logs in {self.host_log_dir} on dokku3."
-                f"Or check logs here with\n"
+                f"Or check logs here with errorlogs head/tail/show, e.g.\n"
                 f"* `@{settings.SLACK_APP_USERNAME} errorlogs tail {self.host_log_dir}`\n"
-                f"* `@{settings.SLACK_APP_USERNAME} errorlogs head {self.host_log_dir}`\n"
                 "Calling tech-support."
             )
             error = True

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -325,6 +325,10 @@ raw_config = {
                 "run_args_template": "/bin/bash show.sh -h {logdir}",
                 "report_stdout": True,
             },
+            "show": {
+                "run_args_template": "/bin/bash show.sh -a {logdir}",
+                "report_stdout": True,
+            },
         },
         "slack": [
             {
@@ -338,6 +342,15 @@ raw_config = {
                 "help": "Show head of an error file located in a [logdir] (a path to a log directory as reported by a failed job)",
                 "action": "schedule_job",
                 "job_type": "head",
+            },
+            {
+                "command": "show [logdir]",
+                "help": (
+                    "Show all of an error file located in a [logdir] (a path to a log directory as reported by a failed job)."
+                    "Note this may return a lot of output split over multiple slack messages."
+                ),
+                "action": "schedule_job",
+                "job_type": "show",
             },
         ],
     }

--- a/workspace/errorlogs/show.sh
+++ b/workspace/errorlogs/show.sh
@@ -2,13 +2,16 @@
 
 set -euo pipefail
 
-while getopts "ht" option; do
+while getopts "hta" option; do
     case $option in
         h)
           command="head"
           ;;
         t)
           command="tail"
+          ;;
+        a)
+          command="all"
           ;;
         \?) # Invalid option
             echo "Error: Invalid option"
@@ -25,10 +28,13 @@ if test -f "$logfile"; then
   echo "Reading $command of error log: $logdir/stderr"
   echo "------------------------------"
   if [[ "$command" == "head" ]]; then
-    head "$logfile"
+    output=$(head "$logfile")
+  elif [[ "$command" == "tail" ]]; then
+    output=$(tail "$logfile")
   else
-    tail "$logfile"
+    output=$(cat "$logfile")
   fi
+  echo "\`\`\`$output\`\`\`"
 else
   echo "ERROR: $logdir/stderr not found"
 fi


### PR DESCRIPTION
In my local testing at least, printing larger log files just split the content over multiple slack messages, rather than causing an error.

It's less pretty than tail/head, because we can't wrap it all in code blocks, but it does seem to be fine to show the entire error log content.