### PR TITLE
Notify users if a job is already running

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -358,13 +358,19 @@ def handle_schedule_job(message, say, slack_config):
     match = slack_config["regex"].match(message["text"])
     job_args = dict(zip(slack_config["template_params"], match.groups()))
     deformatted_args = {k: _remove_url_formatting(v) for k, v in job_args.items()}
-    scheduler.schedule_job(
+    existing_job_is_running = scheduler.schedule_job(
         slack_config["job_type"],
         deformatted_args,
         channel=message["channel"],
         thread_ts=message["ts"],
         delay_seconds=slack_config["delay_seconds"],
     )
+    if existing_job_is_running:
+        say(
+            f"A `{slack_config['job_type']}` job has already started; request queued. "
+            f"Type `@{settings.SLACK_APP_USERNAME} status` to see running jobs, and "
+            f"`@{settings.SLACK_APP_USERNAME} remove job id [id]` to remove a blocking job."
+        )
 
 
 @log_call

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -17,6 +17,14 @@ def assert_suppression_matches(suppression, job_type, start_at, end_at):
     )
 
 
+def assert_running_job(job_scheduled):
+    assert job_scheduled
+
+
+def assert_no_running_job(job_scheuled):
+    assert not job_scheuled
+
+
 def assert_subdict(d1, d2):
     for k in d1:
         assert d1[k] == d2[k]

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -50,6 +50,15 @@ def test_schedule_job(mock_app):
     assert_job_matches(jj[0], "test_good_job", {"n": "10"}, "channel", T(60), None)
 
 
+def test_schedule_job_with_job_already_running(mock_app):
+    with patch("ebmbot.scheduler.schedule_job", return_value=True):
+        handle_message(mock_app, "<@U1234> test do job 1")
+        assert_slack_client_sends_messages(
+            mock_app.recorder,
+            messages_kwargs=[{"channel": "channel", "text": "already started"}],
+        )
+
+
 def test_schedule_job_from_reminder(mock_app):
     handle_message(mock_app, "Reminder: <@U1234|test bot> test do job 10")
 


### PR DESCRIPTION
If a user asks BennettBot to do something, and a job of the same type is already running, the job is scheduled to start once the running job completes.  A job might actually be running, but on occasion a job errors in an unexpected way, so the database isn't updated to fail or complete the job, and the new job will never start (until the old one is manually removed).  This just adds some feedback for the user if their job is being queued.

Fixes #398 