### PR TITLE
Respond to edited tech support messages

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -143,7 +143,7 @@ def register_listeners(app, config, channels, bot_user_id):
         text = event["text"].replace("Reminder: ", "")
         # Remove the bot mention; this sometimes includes the bot's name as well as
         # id. In reminders, the bot mention is in the form <@AB1234|bot_name>; in user
-        # messages that @ the both, it is fjust in the form <@AB1234>. We need to match both.
+        # messages that @ the bot, it is just in the form <@AB1234>. We need to match both.
         text = re.sub(rf"<@{bot_user_id}(|.+)?>", "", text)
 
         # handle extra whitespace and punctuation

--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -172,23 +172,46 @@ def register_listeners(app, config, channels, bot_user_id):
         include_apology = text != "help"
         handle_help(event, say, config["help"], config["description"], include_apology)
 
-    @app.message(
-        tech_support_regex,
+    def tech_support_matcher(event):
         # Only match messages posted outside of the tech support channel itself
-        # and messages that are not posted by a bot (to avoid reposting reminders etc)
-        matchers=[
-            lambda message: message["channel"] != tech_support_channel_id,
-            lambda message: "bot_id" not in message,
-        ],
-    )
-    def repost_to_tech_support(message, say, ack):
-        ack()
+        if event["channel"] == tech_support_channel_id:
+            return False
+        # only match messages that are not posted by a bot, to avoid reposting reminders etc
+        # (the event dict will include the key "bot_id")
+        if "bot_id" in event:
+            return False
+        # Of the available message subtypes, only match "message_changed"; we don't
+        # want to match e.g. "reminder_add" messages that include the word "tech-support"
+        subtype = event.get("subtype")
+        if subtype and subtype != "message_changed":
+            return False
 
+        # match the tech-support keyword
+        text = event.get("message", event)["text"]
+        return tech_support_regex.match(text) is not None
+
+    @app.event(
+        {"type": "message"},
+        matchers=[tech_support_matcher],
+    )
+    def repost_to_tech_support(event, say, ack):
+        # Our matcher filters only allows messages with no subtype (i.e. just
+        # straightforward posts) or message_changed subtype
+        # For edited messages (message_changed), the text is found in the event's
+        # "message"; for other messages, the event itself contains the text
+        message = event.get("message", event)
+        channel = event["channel"]
         # Don't repost messages in DMs with the bot
-        if message["channel_type"] in ["channel", "group"]:
+        # We don't use the matcher for this, because we want to tell users to
+        # call tech-support from a non-dm channel
+        if event["channel_type"] in ["channel", "group"]:
             # Respond with SOS reaction
+            # If we've already responded, the attempt to react here will raise
+            # an exception; if this happens, then the user is editing something
+            # other than the tech-support keyword in the message, and we don't need to
+            # repost it again. We let the default error handler will deal with it.
             app.client.reactions_add(
-                channel=message["channel"], timestamp=message["ts"], name="sos"
+                channel=channel, timestamp=message["ts"], name="sos"
             )
             logger.info("Received tech-support message", message=message["text"])
             # If out of office, respond with an ooo message, but still repost to tech-support channel
@@ -198,18 +221,18 @@ def register_listeners(app, config, channels, bot_user_id):
                 logger.info("Tech support OOO", until=out_of_office_until)
                 say(
                     f"tech-support is currently out of office and will respond after {out_of_office_until}",
-                    channel=message["channel"],
+                    channel=channel,
                     thread_ts=message["ts"],
                 )
 
             message_url = app.client.chat_getPermalink(
-                channel=message["channel"], message_ts=message["ts"]
+                channel=channel, message_ts=message["ts"]
             )["permalink"]
             say(message_url, channel=tech_support_channel_id)
         else:
             say(
                 "Sorry, I can't call tech-support from this conversation.",
-                channel=message["channel"],
+                channel=channel,
             )
 
     @app.event("channel_created")


### PR DESCRIPTION
Second attempt at this with better testing :)

Editing a message to include the tech-support keyword should SOS it and repost it to the tech-support channel. If it was already SOS'd (because the edit is to something other than the keyword), the attempt to react again will fail and be caught by the error handler - which is fine and what we want.

Note that we have to use `@app.event` in order to filter to message subtypes, and not `@app.message`; this also means that we have to include the tech-support keyword regex matcher in the event matchers ourselves (`@app.message` takes a regex and does the matching for us).  This is what went wrong before!