### PR TITLE
Don't repost to tech-support from DMs

### DIFF
--- a/ebmbot/connection.py
+++ b/ebmbot/connection.py
@@ -11,7 +11,8 @@ CREATE TABLE IF NOT EXISTS job (
     channel TEXT,
     thread_ts TEXT,
     start_after DATETIME,
-    started_at DATETIME
+    started_at DATETIME,
+    is_im BOOLEAN
 );
 
 CREATE TABLE IF NOT EXISTS suppression (

--- a/ebmbot/scheduler.py
+++ b/ebmbot/scheduler.py
@@ -6,7 +6,7 @@ from .logger import log_call
 
 
 @log_call
-def schedule_job(type_, args, channel, thread_ts, delay_seconds):
+def schedule_job(type_, args, channel, thread_ts, delay_seconds, is_im=False):
     """Schedule job to be run.
 
     Only one job of any type may be scheduled.  If a job is already scheduled
@@ -33,12 +33,12 @@ def schedule_job(type_, args, channel, thread_ts, delay_seconds):
     existing_jobs = list(conn.execute(sql, [type_]))
     existing_job_running = False
     if len(existing_jobs) == 0:
-        _create_job(type_, args, channel, thread_ts, start_after)
+        _create_job(type_, args, channel, thread_ts, start_after, is_im)
     elif len(existing_jobs) == 1:
         job = existing_jobs[0]
         if job["has_started"]:
             existing_job_running = True
-            _create_job(type_, args, channel, thread_ts, start_after)
+            _create_job(type_, args, channel, thread_ts, start_after, is_im)
         else:
             id_ = job["id"]
             _update_job(id_, args, channel, thread_ts, start_after)
@@ -54,11 +54,11 @@ def schedule_job(type_, args, channel, thread_ts, delay_seconds):
     return existing_job_running
 
 
-def _create_job(type_, args, channel, thread_ts, start_after):
+def _create_job(type_, args, channel, thread_ts, start_after, is_im):
     with get_connection() as conn:
         conn.execute(
-            "INSERT INTO job (type, args, channel, thread_ts, start_after) VALUES (?, ?, ?, ?, ?)",
-            [type_, args, channel, thread_ts, start_after],
+            "INSERT INTO job (type, args, channel, thread_ts, start_after, is_im) VALUES (?, ?, ?, ?, ?, ?)",
+            [type_, args, channel, thread_ts, start_after, is_im],
         )
 
 


### PR DESCRIPTION
Users can have DMs with BennettBot, but they can't call tech-support from DMs, because no-one else will be able to access the message. If a user tries to run a job from a DM with BennettBot, and it fails, it should also not repost to tech-support when it reports the failed job. 