### PR TITLE
Option to restrict jobs to internal users only

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ of `stdout` is read in and posted as the slack message in either [plain text or 
 Jobs are defined in `job_configs.py`. A dict called `raw_config`
 defines which jobs may be run, and how they can be invoked via Slack.
 
-Each key in `raw_config` refers to a job namespace, and maps to a dict that defined
-the namespace jobs in the following format:
+Each key in `raw_config` refers to a category of jobs (the job namespace), and maps to a dict that defines jobs in that category in the following format:
 
 ```
 {
+    "description": "", # Optional description of this category of jobs
+    "restricted": boolean, default=False  # restrict this category to internal users only
     "fabfile": "",  # for fabric commands, location on github of fabfile
     "jobs": {
         # this defines the individual jobs

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -57,6 +57,7 @@ raw_config = {
         ],
     },
     "fdaaa": {
+        "restricted": True,
         "description": "Trials Tracker (https://fdaaa.trialstracker.net)",
         "fabfile": "https://raw.githubusercontent.com/ebmdatalab/clinicaltrials-act-tracker/master/fabfile.py",
         "jobs": {
@@ -74,6 +75,7 @@ raw_config = {
         ],
     },
     "op": {
+        "restricted": True,
         "description": "OpenPrescribing deployment and tools",
         "fabfile": "https://raw.githubusercontent.com/ebmdatalab/openprescribing/main/fabfile.py",
         "jobs": {
@@ -273,6 +275,7 @@ raw_config = {
         ]
     },
     "techsupport": {
+        "restricted": True,
         "description": "Tech Support out of office and rota",
         "jobs": {
             "out_of_office_on": {
@@ -322,6 +325,7 @@ raw_config = {
         ],
     },
     "funding": {
+        "restricted": True,
         "description": "Run funding reports",
         "jobs": {
             "generate_report": {
@@ -396,6 +400,7 @@ def build_config(raw_config):
         "help": {},
         "fabfiles": {},
         "workspace_dir": {},
+        "restricted": {},
     }
 
     for namespace in raw_config:
@@ -403,6 +408,7 @@ def build_config(raw_config):
             raise RuntimeError("Namespaces must not contain underscores")
 
         config["description"][namespace] = raw_config[namespace].get("description", "")
+        config["restricted"][namespace] = raw_config[namespace].get("restricted", False)
 
         helps = []
 

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -122,6 +122,22 @@ raw_config = {
             },
         },
         "slack": [],
+    },
+    "testrestricted": {
+        "restricted": True,
+        "jobs": {
+            "good_job": {
+                "run_args_template": "cat poem",
+            },
+        },
+        "slack": [
+            {
+                "command": "do job",
+                "help": "do the restricted job",
+                "action": "schedule_job",
+                "job_type": "good_job",
+            }
+        ],
     }
 }
 # fmt: on

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -128,7 +128,8 @@ class MockHandler(SimpleHTTPRequestHandler):
             {
                 "ok": True,
                 "members": [
-                    {"name": "test_username", "id": "U1234"},
+                    {"name": "test_username", "id": "U1234", "is_restricted": False},
+                    {"name": "test_guest", "id": "U5678", "is_restricted": True},
                 ],
             }
         ).encode("utf-8"),

--- a/tests/mock_web_api_server.py
+++ b/tests/mock_web_api_server.py
@@ -122,15 +122,32 @@ class MockHandler(SimpleHTTPRequestHandler):
     "user_id": "W99999"
 }
 """
+    users = {
+        "U1234": {
+            "name": "test_username",
+            "id": "U1234",
+            "is_restricted": False,
+            "is_bot": True,
+        },
+        "UINT": {
+            "name": "test_user",
+            "id": "UINT",
+            "is_restricted": False,
+            "is_bot": False,
+        },
+        "UGUEST": {
+            "name": "test_guest",
+            "id": "UGUEST",
+            "is_restricted": True,
+            "is_bot": False,
+        },
+    }
     path_responses = {
         "/webhook": "OK",
         "/users.list": json.dumps(
             {
                 "ok": True,
-                "members": [
-                    {"name": "test_username", "id": "U1234", "is_restricted": False},
-                    {"name": "test_guest", "id": "U5678", "is_restricted": True},
-                ],
+                "members": list(users.values()),
             }
         ).encode("utf-8"),
         "/conversations.list": json.dumps(
@@ -178,6 +195,27 @@ class MockHandler(SimpleHTTPRequestHandler):
             ):
                 # Mock channel members responses to simulate existing membership of one channel
                 body = json.dumps({"ok": True, "members": ["U1234"]}).encode("utf-8")
+            elif path == "/users.info":
+                # This path may be called for mock new users, who are included in the initial
+                # call to /users.
+                new_users = {
+                    "NEWINT": {
+                        "name": "test_new_internal",
+                        "id": "NEWINT",
+                        "is_restricted": False,
+                        "is_bot": False,
+                    },
+                    "NEWGUEST": {
+                        "name": "test_new_guest",
+                        "id": "NEWGUEST",
+                        "is_restricted": True,
+                        "is_bot": False,
+                    },
+                }
+                user = self.users.get(
+                    request_body["user"], new_users.get(request_body["user"])
+                )
+                body = json.dumps({"ok": True, "user": user}).encode("utf-8")
             else:
                 body = self.path_responses.get(path)
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -28,9 +28,9 @@ pytestmark = pytest.mark.freeze_time(T0)
 def register_handler(mock_app):
     app = mock_app.app
     channels = bot.get_channels(app.client)
-    bot_user_id = bot.get_bot_user_id(app.client)
+    bot_user_id, internal_user_ids = bot.get_users_info(app.client)
     bot.join_all_channels(app.client, channels, bot_user_id)
-    bot.register_listeners(app, config, channels, bot_user_id)
+    bot.register_listeners(app, config, channels, bot_user_id, internal_user_ids)
     yield
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -144,12 +144,26 @@ def test_namespace_help(mock_app):
     )
 
 
+def test_restricted_namespace_help(mock_app):
+    handle_message(mock_app, "<@U1234> testrestricted help", reaction_count=0)
+    assert_slack_client_sends_messages(
+        mock_app.recorder,
+        messages_kwargs=[
+            {
+                "channel": "channel",
+                "text": ":lock: These commands are only available to Bennett Institute users",
+            }
+        ],
+    )
+
+
 def test_help(mock_app):
     handle_message(mock_app, "<@U1234> help", reaction_count=0)
     for msg_fragment in [
         "Commands in the following categories are available",
         "* `test`",
         "* `test1`: Test description",
+        "* :lock: `testrestricted`",
     ]:
         assert_slack_client_sends_messages(
             mock_app.recorder,

--- a/tests/test_job_configs.py
+++ b/tests/test_job_configs.py
@@ -10,6 +10,7 @@ def test_build_config():
     raw_config = {
         "ns1": {
             "description": "ns1 jobs",
+            "restricted": True,
             "jobs": {
                 "good_job": {"run_args_template": "cat [poem]"},
                 "bad_job": {"run_args_template": "dog [poem]"},
@@ -163,6 +164,12 @@ def test_build_config():
             "ns2": settings.WRITEABLE_WORKSPACE_DIR,
             "ns3": settings.WRITEABLE_WORKSPACE_DIR,
             "test": settings.WORKSPACE_DIR,
+        },
+        "restricted": {
+            "ns1": True,
+            "ns2": False,
+            "ns3": False,
+            "test": False,
         },
     }
 


### PR DESCRIPTION
Add minimal restrictions that can be applied to categories of jobs, to restrict the entire category to internal users.

For every slack message event sent, the slack API includes a user id, which we can look up to get the value of `is_restricted`, which is True if the user is a guest (i.e. external) user.

I've updated the job config to restrict the jobs that I think we care about - op, fdaaa, funding and techsupport (techsupport for the out of office on/off commands, not the rota).  For the others, I don't _think_ we're concerned about external users seeing the project boards, logs, or outputchecking rota.