### PR TITLE
Fix bug in get_users_info for old users

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -58,7 +58,7 @@ def get_users_info(client):
     internal_user_ids = {
         user["id"]
         for user in users.values()
-        if not user["is_bot"] and not user["is_restricted"]
+        if not user["is_bot"] and not user.get("is_restricted", True)
     }
     return users[settings.SLACK_APP_USERNAME]["id"], internal_user_ids
 


### PR DESCRIPTION
If a user has been removed, they are still returned in the users list, but the "is_restricted" field isn't present