### PR TITLE
Improve output for showlogs commands

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -61,6 +61,7 @@ events.  We need to add some more:
    - `im:read`
    - `reactions:write`
    - `chat:write`
+   - `files:write`
 
 ### Allow users to DM the app
 1. Features > App Home

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The database schema is in `connection.py`, and functions for putting jobs onto t
 A job runs a bash command in a particular job directory or namespace. Each job
 creates a log folder where output and error from the command is written to files named
 `stdout` and `stderr` respectively. If a job is to be reported to slack, the content
-of `stdout` is read in and posted as the slack message in either [plain text or block format](#output-format);
+of `stdout` is read in and posted as the slack message in
+[one of the available formats](#output-format);
 
 Jobs are defined in `job_configs.py`. A dict called `raw_config`
 defines which jobs may be run, and how they can be invoked via Slack.
@@ -39,7 +40,7 @@ Each key in `raw_config` refers to a category of jobs (the job namespace), and m
             "run_args_template": "",  # template of bash command to be run
             "report_stdout": boolean, default=False,  # whether to report contents of stdout to slack
             "report_success": boolean, default=True,  # whether to report success to slack
-            "report_format": "text/blocks",  # format of slack report, plain text or blocks (default="text")
+            "report_format": "text/blocks/code/file",  # format of slack report, plain text, blocks, code or file upload (default="text")
         }
     }
     "slack": [
@@ -197,6 +198,13 @@ can be used for checking your block output is valid.
 
 Note that slack messages can contain a maximum of 50 blocks.
 
+The output can also be `file`; this will be posted as a file snippet instead
+of a message.
+
+Finally, output can also be formatted as code; this will just wrap a plain text
+message in triple backticks for code formatting in Slack. If the message is
+too long for a single Slack message (4000 characters), it will be uploaded
+as a file snippet instead.
 
 ## Deployment docs
 

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -351,14 +351,17 @@ raw_config = {
             "tail": {
                 "run_args_template": "/bin/bash show.sh -t -f {logtype} {logdir}",
                 "report_stdout": True,
+                "report_format": "code",
             },
             "head": {
                 "run_args_template": "/bin/bash show.sh -h -f {logtype} {logdir}",
                 "report_stdout": True,
+                "report_format": "code",
             },
             "all": {
                 "run_args_template": "/bin/bash show.sh -a -f {logtype} {logdir}",
                 "report_stdout": True,
+                "report_format": "code",
             },
         },
         "slack": [
@@ -498,8 +501,11 @@ def validate_job_config(job_type, job_config):
         msg = f"Job {job_type} has extra keys {extra_keys}"
         raise RuntimeError(msg)
 
-    if job_config["report_format"] not in ["text", "blocks"]:
-        msg = f"Job {job_type} has an invalid report_format; must be either 'text' or 'blocks'"
+    if job_config["report_format"] not in ["text", "blocks", "code", "file"]:
+        msg = (
+            f"Job {job_type} has an invalid report_format; must be "
+            "one of 'text', 'blocks', 'code' or 'file'"
+        )
         raise RuntimeError(msg)
 
 

--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -7,21 +7,31 @@ def notify_slack(
     slack_client, channel, message_text, thread_ts=None, message_format=None
 ):
     """Send message to Slack."""
-    msg_kwargs = {"text": str(message_text)}
+    msg_kwargs = {"text": str(message_text), "thread_ts": thread_ts, "channel": channel}
     if message_format == "blocks":
         msg_kwargs["blocks"] = message_text
 
     logger.info(
         "Sending message", channel=channel, message=message_text, thread_ts=thread_ts
     )
+    # If messages are longer than 4000 characters, Slack will split them over
+    # multiple messages. This breaks code formatting, so if a message with code
+    # format is long, we upload it as a file snippet instead
+    if message_format == "code":
+        if len(message_text) > 3990:
+            message_format = "file"
+        else:
+            msg_kwargs["text"] = f"```{msg_kwargs['text']}```"
+
     # In case of any unexpected transient exception posting to slack, retry up to 3
     # times and then log the error, to avoid errors in scheduled jobs.
     attempts = 0
     while attempts < 3:
         try:
-            resp = slack_client.chat_postMessage(
-                channel=channel, thread_ts=thread_ts, **msg_kwargs
-            )
+            if message_format == "file":
+                resp = slack_client.files_upload_v2(content=message_text, **msg_kwargs)
+            else:
+                resp = slack_client.chat_postMessage(**msg_kwargs)
             return resp.data
         except Exception as err:
             attempts += 1

--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -11,8 +11,16 @@ def notify_slack(
     if message_format == "blocks":
         msg_kwargs["blocks"] = message_text
 
+    # Truncate message text to the first charcters
+    log_message_text = message_text[:500]
+    if len(log_message_text) < len(message_text):
+        log_message_text += " (truncated)"
+
     logger.info(
-        "Sending message", channel=channel, message=message_text, thread_ts=thread_ts
+        "Sending message",
+        channel=channel,
+        message=log_message_text,
+        thread_ts=thread_ts,
     )
     # If messages are longer than 4000 characters, Slack will split them over
     # multiple messages. This breaks code formatting, so if a message with code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,14 @@ class WebClientWithSlackException(WebClient):
         raise Exception("Error notifying slack")
 
 
+class MockWebClient(WebClient):
+    def files_upload_v2(self, *args, **kwargs):
+        return Mock(data={"ok": True})
+
+
 @dataclass
 class MockRecordingClient:
-    client: WebClient
+    client: MockWebClient
     recorder: Mock
 
 
@@ -58,7 +63,7 @@ def _get_mock_recording_client(client_class, test_recorder):
 @pytest.fixture
 def mock_client():
     test_recorder = Mock()
-    yield _get_mock_recording_client(WebClient, test_recorder)
+    yield _get_mock_recording_client(MockWebClient, test_recorder)
     cleanup_mock_web_api_server(test_recorder)
 
 

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -56,7 +56,22 @@ raw_config = {
             "python_job_no_output": {
                 "run_args_template": "python jobs.py hello_world_no_output",
                 "report_stdout": True,
-            }
+            },
+            "python_job_long_code_output": {
+                "run_args_template": "python jobs.py long_code_output",
+                "report_format": "code",
+                "report_stdout": True,
+            },
+            "good_job_with_code": {
+                "run_args_template": "cat poem",
+                "report_stdout": True,
+                "report_format": "code"
+            },
+            "good_job_with_file": {
+                "run_args_template": "cat poem",
+                "report_stdout": True,
+                "report_format": "file"
+            },
         },
         "slack": [
             {

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -435,6 +435,40 @@ def test_job_success_config_with_no_python_file(mock_client):
         assert f.read() == ""
 
 
+def test_job_with_code_format(mock_client):
+    scheduler.schedule_job("test_good_job_with_code", {}, "channel", TS, 0)
+    job = scheduler.reserve_job()
+
+    do_job(mock_client.client, job)
+
+    assert_slack_client_sends_messages(
+        mock_client.recorder,
+        messages_kwargs=[
+            {"channel": "logs", "text": "about to start"},
+            {
+                "channel": "channel",
+                "text": "```the owl and the pussycat\n```",
+            },
+        ],
+        message_format="code",
+    )
+
+
+def test_job_with_long_code_output_is_uploaded_as_file(mock_client):
+    scheduler.schedule_job("test_python_job_long_code_output", {}, "channel", TS, 0)
+    job = scheduler.reserve_job()
+
+    do_job(mock_client.client, job)
+
+    assert_slack_client_sends_messages(
+        mock_client.recorder,
+        messages_kwargs=[
+            {"channel": "logs", "text": "about to start"},
+        ],
+        message_format="file",
+    )
+
+
 def do_job(client, job):
     job_dispatcher = JobDispatcher(client, job, config)
     job_dispatcher.do_job()

--- a/tests/workspace/test/jobs.py
+++ b/tests/workspace/test/jobs.py
@@ -18,6 +18,14 @@ def hello_world_blocks_error():
     raise Exception("An error was found!")
 
 
+def long_code_output():
+    """
+    A function that just outputs >4000 characters for
+    testing long code blocks to be uploaded as files
+    """
+    return "\n".join(["Hello" * 10 for i in range(100)])
+
+
 def parse_args():
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(dest="subparser_name")
@@ -30,6 +38,8 @@ def parse_args():
     h3.set_defaults(function=hello_world_blocks_error)
     h4 = subparsers.add_parser("hello_world_no_output")
     h4.set_defaults(function=hello_world)
+    h5 = subparsers.add_parser("long_code_output")
+    h5.set_defaults(function=long_code_output)
     return parser.parse_args()
 
 

--- a/workspace/showlogs/show.sh
+++ b/workspace/showlogs/show.sh
@@ -47,7 +47,7 @@ if test -f "$logfile"; then
   if [[ "$output" == "" ]]; then
     echo "File has no content"
   else
-    echo "\`\`\`$output\`\`\`"
+    echo "$output"
   fi
 else
   echo "ERROR: $logdir/$filename not found"


### PR DESCRIPTION
Addresses the second part of #432 

Slack can handle messages of up to 40K characters, but it will split content across messages, with a maximum of 4000 characters in each message. This breaks our nice code formatting for the showlogs commands.

We could split the message, wrap each chunk in triple backticks and post each message separately - this works, but it's not guaranteed to split the message in sensible places, and breaking across messages isn't great.  If the message is > 4000 characters, we now upload it as a file snippet instead.  Currently this is only done by default for jobs with `code` format specified, so very long plain text messages will still go across multiple messages - but we don't have any of those atm anyway, and there is now a new option to specify `file` as the format in the job config if a new job needed it.

Also truncated messages in logs to 500 characters.