### PR TITLE
Pass thread_ts to successful job notification

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -156,6 +156,7 @@ class JobDispatcher:
             self.slack_client,
             self.job["channel"],
             msg,
+            thread_ts=self.job["thread_ts"],
             message_format=self.job_config["report_format"] if rc == 0 else "text",
         )
         if error and not self.job["is_im"]:


### PR DESCRIPTION
This means responses to commands will get posted as replies rather than as new messages in the channel. The job entry already stored the thread_ts, it just wasn't being passed into the slack notification.

Fixes #432 (along with #436) 