### PR TITLE
Pass thread_ts instead of ts to scheduled jobs

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -235,7 +235,6 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
             logger.info("Received tech-support message", message=message["text"])
             # If out of office, respond with an ooo message, but still repost to tech-support channel
             out_of_office_until = tech_support_out_of_office()
-
             if out_of_office_until:
                 logger.info("Tech support OOO", until=out_of_office_until)
                 say(
@@ -463,7 +462,7 @@ def handle_schedule_job(message, say, slack_config, is_im=False):
         slack_config["job_type"],
         deformatted_args,
         channel=message["channel"],
-        thread_ts=message["ts"],
+        thread_ts=message.get("thread_ts"),
         delay_seconds=slack_config["delay_seconds"],
         is_im=is_im,
     )


### PR DESCRIPTION
Use thread_ts from the original message instead of ts when scheduling jobs. thread_ts may not be present when a command is called directly (not from a thread), which is fine, because the response will be posted into the channel as a new message, which is what we want. It will now only be posted as a reply if it was called from within a thread.