### PR TITLE
Update ppa domain

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # use space efficient utility from base image
 
 RUN --mount=type=cache,target=/var/cache/apt \
-    echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
+    echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
     /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
 
 # install any system dependencies


### PR DESCRIPTION
ppa domains changed in 2022; although the old ones were supposed to remain indefinitely, they're currently inaccessible; but we should update to the new one anyway

https://blog.launchpad.net/ppa/new-domain-names-for-ppas