### PR TITLE
Add `--quiet` flag to NCSO alerts command

### DIFF
--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -104,7 +104,7 @@ raw_config = {
                 "report_stdout": True,
             },
             "ncso_send_alerts": {
-                "run_args_template": "fab --hide=running,stdout,status call_management_command:send_ncso_concessions_alerts,production",
+                "run_args_template": "fab --hide=running,stdout,status call_management_command:send_ncso_concessions_alerts,production,--quiet",
                 "report_stdout": True,
             },
             "import_measure_definition": {


### PR DESCRIPTION
Something about the way fabric/ebmbot work means that stderr gets reported to Slack, interspersed with stdout. This flag disables the stderr logging to stop the command creating a lot of noise in a Slack.

If there's a simple way to get it just report stdout that would also solve the problem, but I couldn't immediately see one.

See also:
 * https://github.com/ebmdatalab/openprescribing/pull/4772