### PR TITLE
Ignore techsupport rota rows without sufficient data

### DIFF
--- a/tests/workspace/tech-support-rota.csv
+++ b/tests/workspace/tech-support-rota.csv
@@ -8,3 +8,4 @@ Week commencing,Primary,Secondary,,Members,Count primary,Count secondary,,Proces
 2023-09-04,"Peter, Steve",Iain,,"Peter, Steve",3,3,,
 2023-09-11,"Peter, Tom W",Ben,,"Peter, Tom W",3,3,,
 2023-09-18,Simon,George,,Simon,3,3,,
+2023-09-25,

--- a/workspace/techsupport/jobs.py
+++ b/workspace/techsupport/jobs.py
@@ -81,7 +81,7 @@ def out_of_office_status():
 
 def report_rota():
     rows = get_rota_data_from_sheet()
-    rota = {row[0]: (row[1], row[2]) for row in rows[1:]}
+    rota = {row[0]: (row[1], row[2]) for row in rows[1:] if len(row) >= 3}
 
     blocks = [
         {


### PR DESCRIPTION
We expect the spreadsheet to contain date,primary name,secondary name in the first 3 columns. We don't want it to break just because the date column has been populated ahead of names being filled in for the rota, so just ignore rows if they don't have data in at least those 3 columns.