### PR TITLE
Improve local dev environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+# secrets
 environment
-.env
-workspace/techsupport/ooo.json
+.env*
 gcp-credentials.json
+# Fabric files that are fetched by jobs
+workspace/op/fabfile.py
+workspace/fdaaa/fabfile.py
+# Files written by jobs
+*techsupport_ooo.json
+logs
+# startup check file, used as a dokku healthcheck
 .bot_startup_check
 
 # System files
@@ -35,4 +42,3 @@ htmlcov
 venv/
 .venv/
 tmp
-logs

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -12,7 +12,7 @@ service (bot, dispatcher and webserver) as defined in the `Procfile`.
 ## Creating the Slack app
 (This should only need to be done once).
 
-ebmbot needs a new-stye Slack app and uses
+ebmbot needs a new-style Slack app and uses
 [socket mode](https://slack.dev/bolt-python/concepts#socket-mode) to listen for messages.
 To create one:
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -4,46 +4,88 @@
 
 ### just
 
+Follow installation instructions from the [Just Programmer's Manual](Follow [installation instructions](https://just.systems/man/en/chapter_4.html) for your OS.
+
+#### Add completion for your shell. E.g. for bash:
+```
+source <(just --completions bash)
+```
+
+#### Show all available commands
+```
+just #  shortcut for just --list
+```
+
+### shellcheck
 ```sh
 # macOS
-brew install just
+brew install shellcheck
 
 # Linux
-# Install from https://github.com/casey/just/releases
-
-# Add completion for your shell. E.g. for bash:
-source <(just --completions bash)
-
-# Show all available commands
-just #  shortcut for just --list
+apt install shellcheck
 ```
 
 
 ## Local development environment
 
+Set up your local .env file by running
 
-Set up a local development environment with:
 ```
-just devenv
+./scripts/local-setup-sh
 ```
 
-This will create a virtual environment, install requurements and create a
-`.env` file by copying `dotenv-sample`; update it as necessary with valid dev
-values for environment variables.
+This will create a `.env` file by copying `dotenv-sample`, and will use the
+Bitwarden CLI to retrieve relevant dev secrets and update environment variables and credentials.
 
 
-### Set up a test slack workspace and app
+### bitwarden CLI
 
-Create a [new slack workspace](https://slack.com/intl/en-gb/get-started#/createnew) to use for testing.
-
-Follow the steps to [create a slack app with the required scopes](DEPLOY.md#creating-the-slack-app)
-and install it into your test workspace.
+If you don't have the Bitwarden CLI already installed, the `local-setup.sh`
+will prompt you to [install it](https://bitwarden.com/help/cli/#download-and-install).
 
 
-### Set up environment
+### Join the test slack workspace
 
-Edit `.env` with the slack app tokens etc for the test slack app.
+Join the test Slack workspace at [bennetttest.slack.com](https://bennetttest.slack.com).
 
+The test slack bot's is already installed to this workspace.  Its username is
+`bennett_test_bot` and, when you are running the bot locally, you can
+interact with it by using `@Bennett Test Bot`.
+
+Alternatively, you can [create your own new slack workspace](https://slack.com/get-started#/createnew) to use for testing, and follow the instructions in the [deployment docs](DEPLOY.md) to create a new test slack app, generate tokens
+and install it to the workspace. You will need to update your `.env` file with
+the relevant environment variables.
+
+## Run locally
+
+### Run checks
+
+Run linter, formatter and shellcheck:
+```
+just check
+```
+
+Fix issues:
+```
+just fix
+```
+
+### Tests
+Run the tests with:
+```
+just test <args>
+```
+
+### Run individual services:
+```
+just run <service>
+```
+
+To run the slack bot and use it to run jobs, run both the bot and dispatcher:
+```
+just run bot
+just run dispatcher
+```
 
 ## Run in docker
 
@@ -95,37 +137,4 @@ Stop running services and remove containers:
 
 ```
 just docker/rm-all
-```
-
-
-
-## Run locally
-
-### Run checks
-
-Run linter and formatter:
-```
-just check
-```
-
-Fix issues:
-```
-just fix
-```
-
-### Tests
-Run the tests with:
-```
-just test <args>
-```
-
-### Run individual services:
-```
-just run <service>
-```
-
-To run the slack bot and test jobs, run both the bot and dispatcher:
-```
-just run bot
-just run dispatcher
 ```

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -10,6 +10,6 @@ SLACK_SIGNING_SECRET=changeme
 SLACK_APP_USERNAME=changeme
 GITHUB_WEBHOOK_SECRET=changeme
 EBMBOT_WEBHOOK_SECRET=changeme
-WEBHOOK_ORIGIN=http(s)://changeme:1234
+WEBHOOK_ORIGIN=http://changeme:1234
 DATA_TEAM_GITHUB_API_TOKEN=changeme
 GCP_CREDENTIALS_PATH=changeme/gcp-credentials.json

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ test *ARGS: devenv
 check *args: devenv
     $BIN/ruff format --diff --quiet .
     $BIN/ruff check --output-format=full .
-
+    shellcheck scripts/*
 
 # fix format and linting
 fix: devenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,4 +85,3 @@ lines-after-imports = 2
 
 [tool.ruff.lint.per-file-ignores]
 "gunicorn/conf.py" = ["INP001"]
-"scripts/setup_gcp_credentials.py" = ["INP001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ dynamic_context = "test_function"
 omit = [
     ".venv/*",
     "venv/*",
+    "scripts/*",
     "fabfile.py",
     "*/__main__.py",
     "tests/mock_web_api_server.py",
@@ -84,3 +85,4 @@ lines-after-imports = 2
 
 [tool.ruff.lint.per-file-ignores]
 "gunicorn/conf.py" = ["INP001"]
+"scripts/setup_gcp_credentials.py" = ["INP001"]

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# make sure a value is set in a .env file
+ensure_value() {
+    local name="$1"
+    local value="$2"
+    local file="$3"
+
+    echo "Setting $name=$value in $file"
+
+    # set naked value
+    if grep -q "^$name=" "$file" 2>/dev/null; then
+        # use '|' sed delimiter as we use '/' in values
+        sed -i "s|^$name=.*|$name=\"$value\"|" "$file"
+    # set and uncomment commented line
+    elif grep -q "^#$name=" "$file" 2>/dev/null; then
+        sed -i "s|^#$name=.*|$name=\"$value\"|" "$file"
+    # append the line as it does not exist
+    else
+        echo "$name=\"$value\"" >> "$file"
+    fi
+}

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -19,15 +19,14 @@ ensure_value SLACK_BENNETT_ADMINS_CHANNEL tech-noise "$ENV_FILE"
 ensure_value SLACK_APP_USERNAME bennett_test_bot "$ENV_FILE"
 ensure_value GCP_CREDENTIALS_PATH "$GCP_CREDENTIALS_PATH" "$ENV_FILE"
 
-# shellcheck disable=SC1091
-. $ENV_FILE
+# shellcheck disable=SC1090
+. "$ENV_FILE"
 
 # setup secrets
 # this only needs to be done very rarely, and bw client is a faff, so add a check to only do it if needed
 if test -n "${CI:-}"; then
     echo "Skipping BW setup as it is CI"
 elif test "$SLACK_BOT_TOKEN" = "changeme" -o -z "$SLACK_BOT_TOKEN"; then
-    tmp=$(mktemp)
     if ! command -v bw > /dev/null; then
         echo "bitwarden cli client bw not found"
         echo "We need it to automatically setup Bennett Bot's SLACK_BOT_TOKEN and other secrets as a one time thing"
@@ -66,6 +65,8 @@ elif test "$SLACK_BOT_TOKEN" = "changeme" -o -z "$SLACK_BOT_TOKEN"; then
     ensure_value DATA_TEAM_GITHUB_API_TOKEN "$(bw get password $DATA_TEAM_GITHUB_API_TOKEN_BW_ID)" "$ENV_FILE"
 
     # create/update the GCP credentials file with the JSON retrieved from bitwarden
+    echo "Writing credentials to $GCP_CREDENTIALS_PATH"
+    # shellcheck disable=SC2005
     echo "$(bw get password $GCP_BW_ID)" > "$GCP_CREDENTIALS_PATH"
 
 else

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -20,7 +20,7 @@ ensure_value SLACK_APP_USERNAME bennett_test_bot "$ENV_FILE"
 ensure_value GCP_CREDENTIALS_PATH "$GCP_CREDENTIALS_PATH" "$ENV_FILE"
 
 # shellcheck disable=SC1091
-. .env
+. $ENV_FILE
 
 # setup secrets
 # this only needs to be done very rarely, and bw client is a faff, so add a check to only do it if needed

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+BASE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && cd .. &> /dev/null && pwd )
+ENV_FILE="$BASE_DIR/.env"
+GCP_CREDENTIALS_PATH="$BASE_DIR/gcp-credentials.json"
+
+# load ensure_values function
+# shellcheck disable=SC1091
+. "$BASE_DIR/scripts/lib.sh"
+
+test -f "$ENV_FILE" || cp "$BASE_DIR/dotenv-sample" "$ENV_FILE"
+
+ensure_value LOGS_DIR "$BASE_DIR/logs" "$ENV_FILE"
+ensure_value WRITEABLE_DIR "$BASE_DIR" "$ENV_FILE"
+ensure_value SLACK_LOGS_CHANNEL tech-noise "$ENV_FILE"
+ensure_value SLACK_TECH_SUPPORT_CHANNEL tech-support-channel "$ENV_FILE"
+ensure_value SLACK_BENNETT_ADMINS_CHANNEL tech-noise "$ENV_FILE"
+ensure_value SLACK_APP_USERNAME bennett_test_bot "$ENV_FILE"
+ensure_value GCP_CREDENTIALS_PATH "$GCP_CREDENTIALS_PATH" "$ENV_FILE"
+
+# shellcheck disable=SC1091
+. .env
+
+# setup secrets
+# this only needs to be done very rarely, and bw client is a faff, so add a check to only do it if needed
+if test -n "${CI:-}"; then
+    echo "Skipping BW setup as it is CI"
+elif test "$SLACK_BOT_TOKEN" = "changeme" -o -z "$SLACK_BOT_TOKEN"; then
+    tmp=$(mktemp)
+    if ! command -v bw > /dev/null; then
+        echo "bitwarden cli client bw not found"
+        echo "We need it to automatically setup Bennett Bot's SLACK_BOT_TOKEN and other secrets as a one time thing"
+        exit 1
+    fi
+    if bw status | grep -q unauthenticated; then
+        echo "You are not logged in to bitwarden (org id is bennettinstitute):"
+        echo
+        echo "   bw login --sso"
+        echo
+        exit 1
+    fi
+
+    session_from_env=${BW_SESSION-"not-found"}
+
+    if test "$session_from_env" = "not-found"; then
+        echo "Unlocking bitwarden..."
+        BW_SESSION=$(bw unlock --raw)
+        export BW_SESSION
+    fi
+
+    # bitwarden item ids
+    SLACK_BOT_TOKEN_BW_ID=2c424941-672a-4bde-847c-b1e70093aadb
+    SLACK_APP_TOKEN_BW_ID=3738619b-4e7d-4932-84b0-b1e700942908
+    SLACK_SIGNING_SECRET_BW_ID=946080f1-c50f-4edf-9773-b1e70095747a
+    DATA_TEAM_GITHUB_API_TOKEN_BW_ID=3c8ca5df-2fa1-49ac-afd6-b1e70092fd2a
+    GCP_BW_ID=62511176-c5bd-4f9c-8de6-b1e700f570b1
+
+    # ensure we have latest passwords
+    bw sync
+
+    # add the secrets to the env file
+    ensure_value SLACK_BOT_TOKEN "$(bw get password $SLACK_BOT_TOKEN_BW_ID)" "$ENV_FILE"
+    ensure_value SLACK_APP_TOKEN "$(bw get password $SLACK_APP_TOKEN_BW_ID)" "$ENV_FILE"
+    ensure_value SLACK_SIGNING_SECRET "$(bw get password $SLACK_SIGNING_SECRET_BW_ID)" "$ENV_FILE"
+    ensure_value DATA_TEAM_GITHUB_API_TOKEN "$(bw get password $DATA_TEAM_GITHUB_API_TOKEN_BW_ID)" "$ENV_FILE"
+
+    # create/update the GCP credentials file with the JSON retrieved from bitwarden
+    echo "$(bw get password $GCP_BW_ID)" > "$GCP_CREDENTIALS_PATH"
+
+else
+    echo "Skipping bitwarden secrets setup as it is already done"
+fi


### PR DESCRIPTION
Fixes #275
Make it easier to run and test changes to BennettBot locally by:
- using an existing test workspace and test slack bot that's already configured
- Adding a script to fetch secrets from Bitwarden and populate the .env file with them
- Some drive-by typo fixes