### PR TITLE
Add dates to tech support rota reports and modified to show any day of week

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.8
+  python: python3.12
 
 repos:
   - repo: local

--- a/tests/test_techsupport_rota.py
+++ b/tests/test_techsupport_rota.py
@@ -15,17 +15,24 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
         {"text": {"text": "Tech support rota", "type": "plain_text"}, "type": "header"},
         {
             "text": {
-                "text": "Primary tech support this week: Iain (secondary: Peter, Steve)",
+                "text": "Primary tech support this week (24/07-28/07): Iain (secondary: Peter, Steve)",
                 "type": "mrkdwn",
             },
             "type": "section",
         },
         {
             "text": {
-                "text": "Primary tech support next week: Ben (secondary: Becky)",
+                "text": "Primary tech support next week (31/07-04/08): Ben (secondary: Becky)",
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8|Open rota spreadsheet>",
+            },
         },
     ]
 
@@ -40,10 +47,24 @@ def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
         {"text": {"text": "Tech support rota", "type": "plain_text"}, "type": "header"},
         {
             "text": {
-                "text": "Primary tech support next week: Ben (secondary: Becky)",
+                "text": "Primary tech support this week (24/07-28/07): Iain (secondary: Peter, Steve)",
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "text": {
+                "text": "Primary tech support next week (31/07-04/08): Ben (secondary: Becky)",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8|Open rota spreadsheet>",
+            },
         },
     ]
 
@@ -69,5 +90,12 @@ def test_rota_report_with_no_future_dates(get_rota_data_from_sheet, freezer):
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8|Open rota spreadsheet>",
+            },
         },
     ]

--- a/workspace/techsupport/jobs.py
+++ b/workspace/techsupport/jobs.py
@@ -8,6 +8,9 @@ from apiclient import discovery
 from google.oauth2 import service_account
 
 
+tech_support_rota_spreadsheet_id = "1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8"
+
+
 def config_file():
     return Path(environ["WRITEABLE_DIR"]) / "techsupport_ooo.json"
 
@@ -18,6 +21,41 @@ def today():
 
 def convert_date(date_string):
     return date.fromisoformat(date_string)
+
+
+def format_week(monday: date):
+    friday = monday + timedelta(days=4)  # Work week
+    return f"{monday.strftime("%d/%m")}-{friday.strftime("%d/%m")}"
+
+
+def get_rota_block_for_week(rota: dict, monday: date, this_or_next: str):
+    try:
+        primary, secondary = rota[str(monday)]
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Primary tech support {this_or_next} week ({format_week(monday)}): {primary} (secondary: {secondary})",
+            },
+        }
+    except KeyError:
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"No rota data found for {this_or_next} week",
+            },
+        }
+
+
+def get_block_linking_rota_spreadsheet(spreadsheet_id):
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f"<https://docs.google.com/spreadsheets/d/{spreadsheet_id}|Open rota spreadsheet>",
+        },
+    }
 
 
 def get_dates_from_config():
@@ -94,52 +132,13 @@ def report_rota():
     ]
 
     today = date.today()
-    if today.weekday() == 0:  # Monday
-        if str(today) in rota:
-            primary, secondary = rota[str(today)]
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"Primary tech support this week: {primary} (secondary: {secondary})",
-                    },
-                }
-            )
-        else:
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "No rota data found for this week",
-                    },
-                }
-            )
+    this_monday = today - timedelta(days=today.weekday())
+    blocks.append(get_rota_block_for_week(rota, this_monday, this_or_next="this"))
 
-    next_monday = str(today + timedelta(7 - today.weekday()))
-    if next_monday in rota:
-        primary, secondary = rota[str(next_monday)]
-        blocks.append(
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"Primary tech support next week: {primary} (secondary: {secondary})",
-                },
-            }
-        )
-    else:
-        blocks.append(
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "No rota data found for next week",
-                },
-            }
-        )
+    next_monday = today + timedelta(7 - today.weekday())
+    blocks.append(get_rota_block_for_week(rota, next_monday, this_or_next="next"))
 
+    blocks.append(get_block_linking_rota_spreadsheet(tech_support_rota_spreadsheet_id))
     return json.dumps(blocks, indent=2)
 
 
@@ -154,7 +153,7 @@ def get_rota_data_from_sheet():  # pragma: no cover
         service.spreadsheets()
         .values()
         .get(
-            spreadsheetId="1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8",
+            spreadsheetId=tech_support_rota_spreadsheet_id,
             range="Rota",
         )
         .execute()


### PR DESCRIPTION
These are changes made in response to #552 (plus changing the precommit config to use python 3.12 instead of 3.8)

- BennettBot now shows the Tech Support rota for the current week and next week regardless of whether it is a Monday. 
- `test_rota_report_on_monday` and `test_rota_report_on_tuesday` are both kept even though now the behaviour does not vary between Monday and Tuesday, as a good-to-have
- As noted in the Issue, dates are now added to the reports
- For convenience, BennettBot now also provides a link to the rota spreadsheet 
- Precommit config yaml now uses Python 3.12 instead of 3.8 to be consistent with the rest of the repo
