### PR TITLE
Make outputchecking/dependabot rotas callable any day of the week

### DIFF
--- a/tests/test_dependabot_rota.py
+++ b/tests/test_dependabot_rota.py
@@ -15,10 +15,17 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
         {"text": {"text": "Dependabot rota", "type": "plain_text"}, "type": "header"},
         {
             "text": {
-                "text": "To review dependabot PRs this week: Lucy",
+                "text": "To review dependabot PRs this week (25 Mar-29 Mar): Lucy",
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU|Open rota spreadsheet>",
+            },
         },
     ]
 
@@ -38,15 +45,36 @@ def test_rota_report_on_monday_with_no_future_dates(get_rota_data_from_sheet, fr
             },
             "type": "section",
         },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU|Open rota spreadsheet>",
+            },
+        },
     ]
 
 
 @patch("workspace.dependabot.jobs.get_rota_data_from_sheet")
 def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
-    freezer.move_to("2023-07-25")
+    freezer.move_to("2024-03-26")
     with open("tests/workspace/dependabot-rota.csv") as f:
         get_rota_data_from_sheet.return_value = list(csv.reader(f))
     blocks = json.loads(report_rota())
     assert blocks == [
         {"text": {"text": "Dependabot rota", "type": "plain_text"}, "type": "header"},
+        {
+            "text": {
+                "text": "To review dependabot PRs this week (25 Mar-29 Mar): Lucy",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU|Open rota spreadsheet>",
+            },
+        },
     ]

--- a/tests/test_dependabot_rota.py
+++ b/tests/test_dependabot_rota.py
@@ -21,6 +21,13 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
             "type": "section",
         },
         {
+            "text": {
+                "text": "To review dependabot PRs next week (01 Apr-05 Apr): Jon",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
@@ -46,6 +53,13 @@ def test_rota_report_on_monday_with_no_future_dates(get_rota_data_from_sheet, fr
             "type": "section",
         },
         {
+            "text": {
+                "text": "No rota data found for next week",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
@@ -66,6 +80,13 @@ def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
         {
             "text": {
                 "text": "To review dependabot PRs this week (25 Mar-29 Mar): Lucy",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "text": {
+                "text": "To review dependabot PRs next week (01 Apr-05 Apr): Jon",
                 "type": "mrkdwn",
             },
             "type": "section",

--- a/tests/test_outputchecking_rota.py
+++ b/tests/test_outputchecking_rota.py
@@ -18,17 +18,24 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
         },
         {
             "text": {
-                "text": "Lead reviewer this week: Louis Fisher (secondary: Colm Andrews)",
+                "text": "Lead reviewer this week (20 Feb-24 Feb): Louis Fisher (secondary: Colm Andrews)",
                 "type": "mrkdwn",
             },
             "type": "section",
         },
         {
             "text": {
-                "text": "Lead reviewer next week: Jon Massey (secondary: Lisa Hopcroft)",
+                "text": "Lead reviewer next week (27 Feb-03 Mar): Jon Massey (secondary: Lisa Hopcroft)",
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY|Open rota spreadsheet>",
+            },
         },
     ]
 
@@ -46,10 +53,24 @@ def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
         },
         {
             "text": {
-                "text": "Lead reviewer next week: Jon Massey (secondary: Lisa Hopcroft)",
+                "text": "Lead reviewer this week (20 Feb-24 Feb): Louis Fisher (secondary: Colm Andrews)",
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "text": {
+                "text": "Lead reviewer next week (27 Feb-03 Mar): Jon Massey (secondary: Lisa Hopcroft)",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY|Open rota spreadsheet>",
+            },
         },
     ]
 
@@ -78,5 +99,12 @@ def test_rota_report_missing_future_dates(get_rota_data_from_sheet, freezer):
                 "type": "mrkdwn",
             },
             "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY|Open rota spreadsheet>",
+            },
         },
     ]

--- a/tests/test_techsupport_rota.py
+++ b/tests/test_techsupport_rota.py
@@ -15,14 +15,14 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
         {"text": {"text": "Tech support rota", "type": "plain_text"}, "type": "header"},
         {
             "text": {
-                "text": "Primary tech support this week (24/07-28/07): Iain (secondary: Peter, Steve)",
+                "text": "Primary tech support this week (24 Jul-28 Jul): Iain (secondary: Peter, Steve)",
                 "type": "mrkdwn",
             },
             "type": "section",
         },
         {
             "text": {
-                "text": "Primary tech support next week (31/07-04/08): Ben (secondary: Becky)",
+                "text": "Primary tech support next week (31 Jul-04 Aug): Ben (secondary: Becky)",
                 "type": "mrkdwn",
             },
             "type": "section",
@@ -47,14 +47,14 @@ def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
         {"text": {"text": "Tech support rota", "type": "plain_text"}, "type": "header"},
         {
             "text": {
-                "text": "Primary tech support this week (24/07-28/07): Iain (secondary: Peter, Steve)",
+                "text": "Primary tech support this week (24 Jul-28 Jul): Iain (secondary: Peter, Steve)",
                 "type": "mrkdwn",
             },
             "type": "section",
         },
         {
             "text": {
-                "text": "Primary tech support next week (31/07-04/08): Ben (secondary: Becky)",
+                "text": "Primary tech support next week (31 Jul-04 Aug): Ben (secondary: Becky)",
                 "type": "mrkdwn",
             },
             "type": "section",

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -62,6 +62,9 @@ def report_rota():
     this_monday = today - timedelta(days=today.weekday())
     blocks.append(get_rota_block_for_week(rota, this_monday, this_or_next="this"))
 
+    next_monday = this_monday + timedelta(days=7)
+    blocks.append(get_rota_block_for_week(rota, next_monday, this_or_next="next"))
+
     blocks.append(get_block_linking_rota_spreadsheet(dependabot_rota_spreadsheet_id))
     return json.dumps(blocks, indent=2)
 

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -1,9 +1,47 @@
 import json
-from datetime import date
+from datetime import date, timedelta
 from os import environ
 
 from apiclient import discovery
 from google.oauth2 import service_account
+
+
+dependabot_rota_spreadsheet_id = "1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU"
+
+
+def format_week(monday: date):
+    friday = monday + timedelta(days=4)  # Work week
+    return f"{monday.strftime("%d %b")}-{friday.strftime("%d %b")}"
+
+
+def get_rota_block_for_week(rota: dict, monday: date, this_or_next: str):
+    try:
+        checker = rota[str(monday)]
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"To review dependabot PRs {this_or_next} week ({format_week(monday)}): {checker}",
+            },
+        }
+    except KeyError:
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"No rota data found for {this_or_next} week",
+            },
+        }
+
+
+def get_block_linking_rota_spreadsheet(spreadsheet_id):
+    return {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f"<https://docs.google.com/spreadsheets/d/{spreadsheet_id}|Open rota spreadsheet>",
+        },
+    }
 
 
 def report_rota():
@@ -21,29 +59,10 @@ def report_rota():
     ]
 
     today = date.today()
-    if today.weekday() == 0:  # Monday
-        if str(today) in rota:
-            checker = rota[str(today)]
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"To review dependabot PRs this week: {checker}",
-                    },
-                }
-            )
-        else:
-            blocks.append(
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "No rota data found for this week",
-                    },
-                }
-            )
+    this_monday = today - timedelta(days=today.weekday())
+    blocks.append(get_rota_block_for_week(rota, this_monday, this_or_next="this"))
 
+    blocks.append(get_block_linking_rota_spreadsheet(dependabot_rota_spreadsheet_id))
     return json.dumps(blocks, indent=2)
 
 
@@ -58,7 +77,7 @@ def get_rota_data_from_sheet():  # pragma: no cover
         service.spreadsheets()
         .values()
         .get(
-            spreadsheetId="1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU",
+            spreadsheetId=dependabot_rota_spreadsheet_id,
             range="Rota",
         )
         .execute()

--- a/workspace/techsupport/jobs.py
+++ b/workspace/techsupport/jobs.py
@@ -25,7 +25,7 @@ def convert_date(date_string):
 
 def format_week(monday: date):
     friday = monday + timedelta(days=4)  # Work week
-    return f"{monday.strftime("%d/%m")}-{friday.strftime("%d/%m")}"
+    return f"{monday.strftime("%d %b")}-{friday.strftime("%d %b")}"
 
 
 def get_rota_block_for_week(rota: dict, monday: date, this_or_next: str):
@@ -135,7 +135,7 @@ def report_rota():
     this_monday = today - timedelta(days=today.weekday())
     blocks.append(get_rota_block_for_week(rota, this_monday, this_or_next="this"))
 
-    next_monday = today + timedelta(7 - today.weekday())
+    next_monday = this_monday + timedelta(days=7)
     blocks.append(get_rota_block_for_week(rota, next_monday, this_or_next="next"))
 
     blocks.append(get_block_linking_rota_spreadsheet(tech_support_rota_spreadsheet_id))


### PR DESCRIPTION
Continues from PR 562. Fixes #552 .

- Date format changed to %d %b for readability
- Outputchecking and dependabot rota now show dates and link to google spreadsheet, consistent with techsupport rota
- Dependabot rota now shows both this and next week purely to be consistent with the other rotas
- Duplicate code is present in all the jobs.py files in the three workspaces. This is deliberate as the duplicate code can be removed easily when addressing #553 .