### PR TITLE
More local setup improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ gcp-credentials.json
 # Fabric files that are fetched by jobs
 workspace/op/fabfile.py
 workspace/fdaaa/fabfile.py
+writeable_dir/
 # Files written by jobs
 *techsupport_ooo.json
 logs

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -89,6 +89,14 @@ just run dispatcher
 
 ## Run in docker
 
+### Update environment
+
+Update the following environment variables in your .env file
+(defaults for docker are included in `dotenv-sample`)
+GCP_CREDENTIALS_PATH="/app/writeable_dir/gcp-credentials.json"
+LOGS_DIR="/app/logs"
+WRITEABLE_DIR="/app/writeable_dir"
+
 ### Build docker image
 
 This builds the dev image by default:

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,6 +1,13 @@
-# See comments in ebmbot/settings.py
+# See comments in ebmbot/settings.py and DEVELPOPERS.md
+# For local dev environments, these variables can be
+# configured by running ./scripts/local-setup.sh
 LOGS_DIR=changeme
 WRITEABLE_DIR=changeme
+GCP_CREDENTIALS_PATH=changeme/gcp-credentials.json
+# Use these settings for running in docker
+# GCP_CREDENTIALS_PATH="/app/writeable_dir/gcp-credentials.json"
+# LOGS_DIR="/app/logs"
+# WRITEABLE_DIR="/app/writeable_dir"
 SLACK_LOGS_CHANNEL=changeme
 SLACK_BENNETT_ADMINS_CHANNEL=changeme
 SLACK_TECH_SUPPORT_CHANNEL=changeme
@@ -12,4 +19,3 @@ GITHUB_WEBHOOK_SECRET=changeme
 EBMBOT_WEBHOOK_SECRET=changeme
 WEBHOOK_ORIGIN=http://changeme:1234
 DATA_TEAM_GITHUB_API_TOKEN=changeme
-GCP_CREDENTIALS_PATH=changeme/gcp-credentials.json

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -5,9 +5,9 @@ LOGS_DIR=changeme
 WRITEABLE_DIR=changeme
 GCP_CREDENTIALS_PATH=changeme/gcp-credentials.json
 # Use these settings for running in docker
-# GCP_CREDENTIALS_PATH="/app/writeable_dir/gcp-credentials.json"
 # LOGS_DIR="/app/logs"
 # WRITEABLE_DIR="/app/writeable_dir"
+# GCP_CREDENTIALS_PATH="/app/writeable_dir/gcp-credentials.json"
 SLACK_LOGS_CHANNEL=changeme
 SLACK_BENNETT_ADMINS_CHANNEL=changeme
 SLACK_TECH_SUPPORT_CHANNEL=changeme

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,6 +1,6 @@
 # See comments in ebmbot/settings.py
 LOGS_DIR=changeme
-WRITEABLE_DIR=.
+WRITEABLE_DIR=changeme
 SLACK_LOGS_CHANNEL=changeme
 SLACK_BENNETT_ADMINS_CHANNEL=changeme
 SLACK_TECH_SUPPORT_CHANNEL=changeme

--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -57,6 +57,29 @@ raw_config = {
             },
         ],
     },
+    "test-remote": {
+        "description": "Some commands to test remote jobs work",
+        # Note: we're making use of the fabfile config here to fetch a file
+        # from a remote repo.
+        # The file it's fetching is just a standard python file, not a fabfile,
+        # but the job will fetch and write it as 'fabfile.py' irrespective of its
+        # original name - so we need to run it with `python fabfile.py`
+        "fabfile": "https://raw.githubusercontent.com/ebmdatalab/ebmbot/main/workspace/test/jobs.py",
+        "jobs": {
+            "hello_world": {
+                "run_args_template": "python fabfile.py",
+                "report_stdout": True,
+            },
+        },
+        "slack": [
+            {
+                "command": "hello",
+                "help": "A test job that runs a script fetched from a remote location",
+                "action": "schedule_job",
+                "job_type": "hello_world",
+            },
+        ]
+    },
     "fdaaa": {
         "restricted": True,
         "description": "Trials Tracker (https://fdaaa.trialstracker.net)",

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -3,7 +3,11 @@ set -euo pipefail
 
 BASE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && cd .. &> /dev/null && pwd )
 ENV_FILE="$BASE_DIR/.env"
-GCP_CREDENTIALS_PATH="$BASE_DIR/gcp-credentials.json"
+WRITEABLE_DIR="$BASE_DIR/writeable_dir"
+GCP_CREDENTIALS_PATH="$WRITEABLE_DIR/gcp-credentials.json"
+
+# ensure writeable_dir exists
+mkdir -p "$WRITEABLE_DIR"
 
 # load ensure_values function
 # shellcheck disable=SC1091
@@ -12,7 +16,7 @@ GCP_CREDENTIALS_PATH="$BASE_DIR/gcp-credentials.json"
 test -f "$ENV_FILE" || cp "$BASE_DIR/dotenv-sample" "$ENV_FILE"
 
 ensure_value LOGS_DIR "$BASE_DIR/logs" "$ENV_FILE"
-ensure_value WRITEABLE_DIR "$BASE_DIR" "$ENV_FILE"
+ensure_value WRITEABLE_DIR "$WRITEABLE_DIR" "$ENV_FILE"
 ensure_value SLACK_LOGS_CHANNEL tech-noise "$ENV_FILE"
 ensure_value SLACK_TECH_SUPPORT_CHANNEL tech-support-channel "$ENV_FILE"
 ensure_value SLACK_BENNETT_ADMINS_CHANNEL tech-noise "$ENV_FILE"


### PR DESCRIPTION
- Set local WRITEABLE_DIR to a different location to workspace/
- Add docker environment variables to dotenv-sample and docs, to specify paths that need to be different when running in docker rather than locally
- Add a test job for testing fetching remote files and using them to run jobs (because we can't run fabric jobs locally, and those are the only ones that do this)