### PR TITLE
Share code between different rota reporting functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Some caveats:
 - Scripts run in a job have access to all environment variables, but they do not have
   access to the app itself, so e.g. can't use `ebmbot.settings`; use the environment
   variables these are based on instead.
-- PYTHONPATH is set to the parent of the workspace directory, so scripts can access other
+- PYTHONPATH is set to the root directory of the application, so scripts can access other
   modules under `workspace`.
 - If a script needs to write to the filesystem, it MUST write to a location within
   `WRITEABLE_DIR`, not its namespace directory.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Some caveats:
   access to the app itself, so e.g. can't use `ebmbot.settings`; use the environment
   variables these are based on instead.
 - PYTHONPATH is set to the root directory of the application, so scripts can access other
-  modules under `workspace`.
+  modules.
 - If a script needs to write to the filesystem, it MUST write to a location within
   `WRITEABLE_DIR`, not its namespace directory.
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Some caveats:
 - Scripts run in a job have access to all environment variables, but they do not have
   access to the app itself, so e.g. can't use `ebmbot.settings`; use the environment
   variables these are based on instead.
-- PYTHONPATH is set to the parent workspace directory, so scripts can access other
-  modules under `workspace`).
+- PYTHONPATH is set to the parent of the workspace directory, so scripts can access other
+  modules under `workspace`.
 - If a script needs to write to the filesystem, it MUST write to a location within
   `WRITEABLE_DIR`, not its namespace directory.
 

--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -104,7 +104,7 @@ class JobDispatcher:
                     cwd=self.cwd,
                     stdout=stdout,
                     stderr=stderr,
-                    env={**os.environ, "PYTHONPATH": self.workspace_dir.parent},
+                    env={**os.environ, "PYTHONPATH": settings.APPLICATION_ROOT},
                     shell=True,
                 )
                 rc = rv.returncode

--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -104,7 +104,7 @@ class JobDispatcher:
                     cwd=self.cwd,
                     stdout=stdout,
                     stderr=stderr,
-                    env={**os.environ, "PYTHONPATH": self.workspace_dir},
+                    env={**os.environ, "PYTHONPATH": self.workspace_dir.parent},
                     shell=True,
                 )
                 rc = rv.returncode

--- a/tests/test_dependabot_rota.py
+++ b/tests/test_dependabot_rota.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from workspace.dependabot.jobs import report_rota
 
 
-@patch("workspace.dependabot.jobs.get_rota_data_from_sheet")
+@patch("workspace.dependabot.jobs.DependabotRotaReporter.get_rota_data_from_sheet")
 def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
     freezer.move_to("2024-03-25")
     with open("tests/workspace/dependabot-rota.csv") as f:
@@ -37,7 +37,7 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
     ]
 
 
-@patch("workspace.dependabot.jobs.get_rota_data_from_sheet")
+@patch("workspace.dependabot.jobs.DependabotRotaReporter.get_rota_data_from_sheet")
 def test_rota_report_on_monday_with_no_future_dates(get_rota_data_from_sheet, freezer):
     freezer.move_to("2024-10-07")
     with open("tests/workspace/dependabot-rota.csv") as f:
@@ -69,7 +69,7 @@ def test_rota_report_on_monday_with_no_future_dates(get_rota_data_from_sheet, fr
     ]
 
 
-@patch("workspace.dependabot.jobs.get_rota_data_from_sheet")
+@patch("workspace.dependabot.jobs.DependabotRotaReporter.get_rota_data_from_sheet")
 def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
     freezer.move_to("2024-03-26")
     with open("tests/workspace/dependabot-rota.csv") as f:

--- a/tests/test_outputchecking_rota.py
+++ b/tests/test_outputchecking_rota.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 from workspace.outputchecking.jobs import report_rota
 
 
-@patch("workspace.outputchecking.jobs.get_rota_data_from_sheet")
+@patch(
+    "workspace.outputchecking.jobs.OutputCheckingRotaReporter.get_rota_data_from_sheet"
+)
 def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
     freezer.move_to("2023-02-20")
     with open("tests/workspace/output-checking-rota.csv") as f:
@@ -40,7 +42,9 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
     ]
 
 
-@patch("workspace.outputchecking.jobs.get_rota_data_from_sheet")
+@patch(
+    "workspace.outputchecking.jobs.OutputCheckingRotaReporter.get_rota_data_from_sheet"
+)
 def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
     freezer.move_to("2023-02-21")
     with open("tests/workspace/output-checking-rota.csv") as f:
@@ -75,7 +79,9 @@ def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
     ]
 
 
-@patch("workspace.outputchecking.jobs.get_rota_data_from_sheet")
+@patch(
+    "workspace.outputchecking.jobs.OutputCheckingRotaReporter.get_rota_data_from_sheet"
+)
 def test_rota_report_missing_future_dates(get_rota_data_from_sheet, freezer):
     freezer.move_to("2024-01-08")
     with open("tests/workspace/output-checking-rota.csv") as f:

--- a/tests/test_techsupport_rota.py
+++ b/tests/test_techsupport_rota.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from workspace.techsupport.jobs import report_rota
 
 
-@patch("workspace.techsupport.jobs.get_rota_data_from_sheet")
+@patch("workspace.techsupport.jobs.TechSupportRotaReporter.get_rota_data_from_sheet")
 def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
     freezer.move_to("2023-07-24")
     with open("tests/workspace/tech-support-rota.csv") as f:
@@ -37,7 +37,7 @@ def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
     ]
 
 
-@patch("workspace.techsupport.jobs.get_rota_data_from_sheet")
+@patch("workspace.techsupport.jobs.TechSupportRotaReporter.get_rota_data_from_sheet")
 def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
     freezer.move_to("2023-07-25")
     with open("tests/workspace/tech-support-rota.csv") as f:
@@ -69,7 +69,7 @@ def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
     ]
 
 
-@patch("workspace.techsupport.jobs.get_rota_data_from_sheet")
+@patch("workspace.techsupport.jobs.TechSupportRotaReporter.get_rota_data_from_sheet")
 def test_rota_report_with_no_future_dates(get_rota_data_from_sheet, freezer):
     freezer.move_to("2024-01-08")
     with open("tests/workspace/tech-support-rota.csv") as f:

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -1,90 +1,29 @@
-import json
-from datetime import date, timedelta
-from os import environ
+from datetime import date
 
-from apiclient import discovery
-from google.oauth2 import service_account
+from workspace.utils.rota import RotaReporter
 
 
-dependabot_rota_spreadsheet_id = "1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU"
+class DependabotRotaReporter(RotaReporter):
+    def __init__(self):
+        super().__init__(
+            title="Dependabot rota",
+            spreadsheet_id="1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU",
+            sheet_range="Rota",
+        )
 
+    def convert_rota_data_to_dictionary(self, rows) -> dict:
+        return {row[0]: row[1] for row in rows[1:]}
 
-def format_week(monday: date):
-    friday = monday + timedelta(days=4)  # Work week
-    return f"{monday.strftime("%d %b")}-{friday.strftime("%d %b")}"
-
-
-def get_rota_block_for_week(rota: dict, monday: date, this_or_next: str):
-    try:
-        checker = rota[str(monday)]
-        return {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"To review dependabot PRs {this_or_next} week ({format_week(monday)}): {checker}",
-            },
-        }
-    except KeyError:
-        return {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"No rota data found for {this_or_next} week",
-            },
-        }
-
-
-def get_block_linking_rota_spreadsheet(spreadsheet_id):
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": f"<https://docs.google.com/spreadsheets/d/{spreadsheet_id}|Open rota spreadsheet>",
-        },
-    }
+    def get_rota_text_for_week(self, rota: dict, monday: date, this_or_next: str):
+        try:
+            checker = rota[str(monday)]
+            return f"To review dependabot PRs {this_or_next} week ({self.format_week(monday)}): {checker}"
+        except KeyError:
+            return f"No rota data found for {this_or_next} week"
 
 
 def report_rota():
-    rows = get_rota_data_from_sheet()
-    rota = {row[0]: row[1] for row in rows[1:]}
-
-    blocks = [
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": "Dependabot rota",
-            },
-        },
-    ]
-
-    today = date.today()
-    this_monday = today - timedelta(days=today.weekday())
-    blocks.append(get_rota_block_for_week(rota, this_monday, this_or_next="this"))
-
-    next_monday = this_monday + timedelta(days=7)
-    blocks.append(get_rota_block_for_week(rota, next_monday, this_or_next="next"))
-
-    blocks.append(get_block_linking_rota_spreadsheet(dependabot_rota_spreadsheet_id))
-    return json.dumps(blocks, indent=2)
-
-
-def get_rota_data_from_sheet():  # pragma: no cover
-    credentials = service_account.Credentials.from_service_account_file(
-        environ["GCP_CREDENTIALS_PATH"],
-        scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
-    )
-    service = discovery.build("sheets", "v4", credentials=credentials)
-
-    return (
-        service.spreadsheets()
-        .values()
-        .get(
-            spreadsheetId=dependabot_rota_spreadsheet_id,
-            range="Rota",
-        )
-        .execute()
-    )["values"]
+    return DependabotRotaReporter().report()
 
 
 if __name__ == "__main__":

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -4,13 +4,6 @@ from workspace.utils.rota import RotaReporter
 
 
 class DependabotRotaReporter(RotaReporter):
-    def __init__(self):
-        super().__init__(
-            title="Dependabot rota",
-            spreadsheet_id="1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU",
-            sheet_range="Rota",
-        )
-
     def convert_rota_data_to_dictionary(self, rows) -> dict:
         return {row[0]: row[1] for row in rows[1:]}
 
@@ -23,7 +16,11 @@ class DependabotRotaReporter(RotaReporter):
 
 
 def report_rota():
-    return DependabotRotaReporter().report()
+    return DependabotRotaReporter(
+        title="Dependabot rota",
+        spreadsheet_id="1mxAks8tfVEBTSarKoNREsdztW3bTqvIPgV-83GY6CFU",
+        sheet_range="Rota",
+    ).report()
 
 
 if __name__ == "__main__":

--- a/workspace/outputchecking/jobs.py
+++ b/workspace/outputchecking/jobs.py
@@ -4,13 +4,6 @@ from workspace.utils.rota import RotaReporter
 
 
 class OutputCheckingRotaReporter(RotaReporter):
-    def __init__(self):
-        super().__init__(
-            title="Output checking rota",
-            spreadsheet_id="1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY",
-            sheet_range="Rota 2024",
-        )
-
     def convert_rota_data_to_dictionary(self, rows) -> dict:
         return {row[0]: (row[1], row[2]) for row in rows[1:] if len(row) >= 3}
 
@@ -23,7 +16,11 @@ class OutputCheckingRotaReporter(RotaReporter):
 
 
 def report_rota():
-    return OutputCheckingRotaReporter().report()
+    return OutputCheckingRotaReporter(
+        title="Output checking rota",
+        spreadsheet_id="1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY",
+        sheet_range="Rota 2024",
+    ).report()
 
 
 if __name__ == "__main__":

--- a/workspace/outputchecking/jobs.py
+++ b/workspace/outputchecking/jobs.py
@@ -1,88 +1,29 @@
-import json
-from datetime import date, timedelta
-from os import environ
+from datetime import date
 
-from apiclient import discovery
-from google.oauth2 import service_account
+from workspace.utils.rota import RotaReporter
 
 
-outputchecking_rota_spreadsheet_id = "1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY"
+class OutputCheckingRotaReporter(RotaReporter):
+    def __init__(self):
+        super().__init__(
+            title="Output checking rota",
+            spreadsheet_id="1i3D_HtuYUCU_dqvRug94YkfK6pG4ECyxTdOangubUlY",
+            sheet_range="Rota 2024",
+        )
 
+    def convert_rota_data_to_dictionary(self, rows) -> dict:
+        return {row[0]: (row[1], row[2]) for row in rows[1:] if len(row) >= 3}
 
-def format_week(monday: date):
-    friday = monday + timedelta(days=4)  # Work week
-    return f"{monday.strftime("%d %b")}-{friday.strftime("%d %b")}"
-
-
-def get_rota_block_for_week(rota: dict, monday: date, this_or_next: str):
-    try:
-        primary, secondary = rota[str(monday)]
-        return {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"Lead reviewer {this_or_next} week ({format_week(monday)}): {primary} (secondary: {secondary})",
-            },
-        }
-    except KeyError:
-        return {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"No rota data found for {this_or_next} week",
-            },
-        }
-
-
-def get_block_linking_rota_spreadsheet(spreadsheet_id):
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": f"<https://docs.google.com/spreadsheets/d/{spreadsheet_id}|Open rota spreadsheet>",
-        },
-    }
+    def get_rota_text_for_week(self, rota: dict, monday: date, this_or_next: str):
+        try:
+            primary, secondary = rota[str(monday)]
+            return f"Lead reviewer {this_or_next} week ({self.format_week(monday)}): {primary} (secondary: {secondary})"
+        except KeyError:
+            return f"No rota data found for {this_or_next} week"
 
 
 def report_rota():
-    rows = get_rota_data_from_sheet()
-    rota = {row[0]: (row[1], row[2]) for row in rows[1:] if len(row) >= 3}
-    blocks = [
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": "Output checking rota",
-            },
-        },
-    ]
-    today = date.today()
-    this_monday = today - timedelta(days=today.weekday())
-    blocks.append(get_rota_block_for_week(rota, this_monday, this_or_next="this"))
-
-    next_monday = this_monday + timedelta(days=7)
-    blocks.append(get_rota_block_for_week(rota, next_monday, this_or_next="next"))
-    blocks.append(
-        get_block_linking_rota_spreadsheet(outputchecking_rota_spreadsheet_id)
-    )
-    return json.dumps(blocks, indent=2)
-
-
-def get_rota_data_from_sheet():  # pragma: no cover
-    credentials = service_account.Credentials.from_service_account_file(
-        environ["GCP_CREDENTIALS_PATH"],
-        scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
-    )
-    service = discovery.build("sheets", "v4", credentials=credentials)
-    return (
-        service.spreadsheets()
-        .values()
-        .get(
-            spreadsheetId=outputchecking_rota_spreadsheet_id,
-            range="Rota 2024",
-        )
-        .execute()
-    )["values"]
+    return OutputCheckingRotaReporter().report()
 
 
 if __name__ == "__main__":

--- a/workspace/techsupport/jobs.py
+++ b/workspace/techsupport/jobs.py
@@ -79,13 +79,6 @@ def out_of_office_status():
 
 
 class TechSupportRotaReporter(RotaReporter):
-    def __init__(self):
-        super().__init__(
-            title="Tech support rota",
-            spreadsheet_id="1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8",
-            sheet_range="Rota",
-        )
-
     @staticmethod
     def convert_rota_data_to_dictionary(rows) -> dict:
         rota = {row[0]: (row[1], row[2]) for row in rows[1:] if len(row) >= 3}
@@ -100,7 +93,11 @@ class TechSupportRotaReporter(RotaReporter):
 
 
 def report_rota():
-    return TechSupportRotaReporter().report()
+    return TechSupportRotaReporter(
+        title="Tech support rota",
+        spreadsheet_id="1q6EzPQ9iG9Rb-VoYvylObhsJBckXuQdt3Y_pOGysxG8",
+        sheet_range="Rota",
+    ).report()
 
 
 if __name__ == "__main__":

--- a/workspace/techsupport/jobs.py
+++ b/workspace/techsupport/jobs.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from os import environ
 from pathlib import Path
 
-from ..utils.rota import RotaReporter
+from workspace.utils.rota import RotaReporter
 
 
 def config_file():

--- a/workspace/utils/blocks.py
+++ b/workspace/utils/blocks.py
@@ -1,0 +1,8 @@
+def get_text_block(text, block_type="section", text_type="mrkdwn"):
+    return {
+        "type": block_type,
+        "text": {
+            "type": text_type,
+            "text": text,
+        },
+    }

--- a/workspace/utils/rota.py
+++ b/workspace/utils/rota.py
@@ -1,0 +1,98 @@
+import abc
+import json
+from datetime import date, timedelta
+from os import environ
+
+from apiclient import discovery
+from google.oauth2 import service_account
+
+
+class RotaReporter(abc.ABC):
+    def __init__(self, title: str, spreadsheet_id: str, sheet_range: str):
+        self.title = title
+        self.spreadsheet_id = spreadsheet_id
+        self.sheet_range = sheet_range
+        pass
+
+    def get_rota_data_from_sheet(self):  # pragma: no cover
+        credentials = service_account.Credentials.from_service_account_file(
+            environ["GCP_CREDENTIALS_PATH"],
+            scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
+        )
+        service = discovery.build("sheets", "v4", credentials=credentials)
+        return (
+            service.spreadsheets()
+            .values()
+            .get(
+                spreadsheetId=self.spreadsheet_id,
+                range=self.sheet_range,
+            )
+            .execute()
+        )["values"]
+
+    def report(self):
+        rota = self.get_rota()
+        blocks = [self.get_header_block()]
+
+        today = date.today()
+        this_monday = today - timedelta(days=today.weekday())
+        blocks.append(
+            self.get_rota_block_for_week(rota, this_monday, this_or_next="this")
+        )
+
+        next_monday = this_monday + timedelta(days=7)
+        blocks.append(
+            self.get_rota_block_for_week(rota, next_monday, this_or_next="next")
+        )
+
+        blocks.append(self.get_block_linking_rota_spreadsheet())
+        return json.dumps(blocks, indent=2)
+
+    def get_rota(self):
+        rows = self.get_rota_data_from_sheet()
+        rota = self.convert_rota_data_to_dictionary(rows)
+        return rota
+
+    @abc.abstractmethod
+    def convert_rota_data_to_dictionary(self) -> dict:
+        """
+        Takes the rows returned from get_rota_data_from_sheet and converts them into a dictionary with dates as keys
+        """
+
+    def get_header_block(self):
+        return {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": self.title,
+            },
+        }
+
+    @abc.abstractmethod
+    def get_rota_text_for_week(self, rota: dict, monday: date, this_or_next: str):
+        """
+        Returns plain text reporting either the rota or a message saying no rota data was found
+        """
+
+    def get_rota_block_for_week(self, rota: dict, monday: date, this_or_next: str):
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": self.get_rota_text_for_week(rota, monday, this_or_next),
+            },
+        }
+
+    def get_block_linking_rota_spreadsheet(self):
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"<https://docs.google.com/spreadsheets/d/{self.spreadsheet_id}|Open rota spreadsheet>",
+            },
+        }
+
+    @staticmethod
+    def format_week(monday: date):
+        friday = monday + timedelta(days=4)  # Work week
+        return f"{monday.strftime("%d %b")}-{friday.strftime("%d %b")}"

--- a/workspace/utils/rota.py
+++ b/workspace/utils/rota.py
@@ -1,10 +1,8 @@
 import abc
 import json
 from datetime import date, timedelta
-from os import environ
 
-from apiclient import discovery
-from google.oauth2 import service_account
+from workspace.utils.spreadsheets import get_data_from_sheet
 
 
 class RotaReporter(abc.ABC):
@@ -15,20 +13,7 @@ class RotaReporter(abc.ABC):
         pass
 
     def get_rota_data_from_sheet(self):  # pragma: no cover
-        credentials = service_account.Credentials.from_service_account_file(
-            environ["GCP_CREDENTIALS_PATH"],
-            scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
-        )
-        service = discovery.build("sheets", "v4", credentials=credentials)
-        return (
-            service.spreadsheets()
-            .values()
-            .get(
-                spreadsheetId=self.spreadsheet_id,
-                range=self.sheet_range,
-            )
-            .execute()
-        )["values"]
+        return get_data_from_sheet(self.spreadsheet_id, self.sheet_range)
 
     def report(self):
         rota = self.get_rota()

--- a/workspace/utils/spreadsheets.py
+++ b/workspace/utils/spreadsheets.py
@@ -1,0 +1,21 @@
+from os import environ
+
+from apiclient import discovery
+from google.oauth2 import service_account
+
+
+def get_data_from_sheet(spreadsheet_id, sheet_range):  # pragma: no cover
+    credentials = service_account.Credentials.from_service_account_file(
+        environ["GCP_CREDENTIALS_PATH"],
+        scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
+    )
+    service = discovery.build("sheets", "v4", credentials=credentials)
+    return (
+        service.spreadsheets()
+        .values()
+        .get(
+            spreadsheetId=spreadsheet_id,
+            range=sheet_range,
+        )
+        .execute()
+    )["values"]


### PR DESCRIPTION
Fixes #553.
- Currently BennettBot handles 3 different rotas which results 3 files in 3 different namespaces containing duplicate code
- To remove duplicate code, create ```utils``` modules called ```rota``` and ```spreadsheet``` to hold the common code
- Create the ```RotaReporter``` base class and inherited classes for each rota
- In order for the utils module to be detected, the PYTHONPATH set for the dispatcher had to be changed to be the root of the application. ```README.md``` is updated accordingly