### PR TITLE
Increase the delay for the MessageChecker loop

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -246,9 +246,13 @@ class MessageChecker:
         p.start()
         return p
 
-    def do_check(self, run_fn=lambda: True, delay=5):  # pragma: no branch
+    def do_check(self, run_fn=lambda: True, delay=10):  # pragma: no branch
         # In production, we want this check to run forever. Using a
         # function means that we can test it on a finite number of loops.
+        # Note that the message search endpoint is a tier2 endpoint and is
+        # rate limited at around 20 calls per min
+        # https://api.slack.com/apis/rate-limits#tier_t2
+        # A 10s delay should be safe for our 2 calls per loop
         while run_fn():
             today = datetime.today()
             yesterday = (today - timedelta(days=1)).strftime("%Y-%m-%d")


### PR DESCRIPTION
search.messages is tier 2 rate limited in slack, which allows around 20 calls per min. Our 2 calls per loop every 5 seconds was - just - exceeding this, so increasing it to run every 10 seconds should hopefully be safe.