### PR TITLE
Have Slack send an error message if a message failed to post

### DIFF
--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -72,14 +72,12 @@ def notify_slack(
 
 
 def get_slack_error_blocks(header_text, message_text, error):
-    error_text = f"```{str(error)}```"
-    message_text = f"```{message_text}```"
     return get_basic_header_and_text_blocks(
         header_text=header_text,
         texts=[
             "Slack encountered the error",
-            truncate_text(error_text),
+            f"```{truncate_text(str(error), max_len=2994)}```",
             "when trying to post the following message:",
-            truncate_text(message_text),
+            f"```{truncate_text(message_text,max_len=2994)}```",
         ],
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+from workspace.utils.blocks import truncate_text
+
+
+def test_truncate_text():
+    original_text = "hello" * 1000
+    truncated_text = truncate_text(original_text)
+    assert len(truncated_text) == 3000
+    assert truncated_text.endswith("...")

--- a/workspace/funding/funding_report.py
+++ b/workspace/funding/funding_report.py
@@ -1,7 +1,7 @@
 import json
 from datetime import date, datetime
 
-from workspace.utils.blocks import get_text_block
+from workspace.utils.blocks import get_header_block, get_text_block
 from workspace.utils.spreadsheets import get_data_from_sheet
 
 
@@ -77,13 +77,7 @@ def main():
         key=lambda row: (types.index(row["type"]), str(row["deadline_date"]))
     )
 
-    blocks = [
-        get_text_block(
-            ":moneybag: *Funding update* :moneybag:",
-            block_type="header",
-            text_type="plain_text",
-        ),
-    ]
+    blocks = [get_header_block(":moneybag: *Funding update* :moneybag:")]
 
     if calls_recently_added:  # pragma: no branch
         blocks.extend(

--- a/workspace/report/generate_report.py
+++ b/workspace/report/generate_report.py
@@ -4,6 +4,8 @@ import os
 
 import requests
 
+from workspace.utils.blocks import get_basic_header_and_text_blocks
+
 
 URL = "https://api.github.com/graphql"
 TOKEN = os.environ["DATA_TEAM_GITHUB_API_TOKEN"]  # requires "read:project" and "repo"
@@ -32,22 +34,10 @@ def main(project_num, statuses):
         if status and status in statuses:
             tickets_by_status[status].append(summary)
 
-    report_output = [
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": ":newspaper: Project Board Summary :newspaper:",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"<https://github.com/orgs/opensafely-core/projects/{project_num}/views/1|View board>",
-            },
-        },
-    ]
+    report_output = get_basic_header_and_text_blocks(
+        header_text=":newspaper: Project Board Summary :newspaper:",
+        texts=f"<https://github.com/orgs/opensafely-core/projects/{project_num}/views/1|View board>",
+    )
 
     for status, tickets in tickets_by_status.items():
         if tickets:

--- a/workspace/utils/blocks.py
+++ b/workspace/utils/blocks.py
@@ -24,9 +24,16 @@ def get_basic_header_and_text_blocks(
     header_block = get_header_block(header_text)
     if isinstance(texts, str):
         texts = [texts]
-    if len(texts) > 49:
+    if len(texts) > 49:  # pragma: no cover
         raise ValueError(
             f"""Slack has a limit of 50 blocks per message. Currently there are {len(texts)+1} blocks including the header block."""
         )
     text_blocks = [get_text_block(text, text_type=text_type) for text in texts]
     return [header_block] + text_blocks
+
+
+def truncate_text(text, max_len=3000):
+    # Slack has a limit of 3000 characters per text block
+    if len(text) > max_len:
+        text = text[: max_len - 3] + "..."
+    return text

--- a/workspace/utils/blocks.py
+++ b/workspace/utils/blocks.py
@@ -19,7 +19,7 @@ def get_basic_header_and_text_blocks(
     Returns a list of blocks: a header block and text blocks with little room for customization.
     "texts" can be a list of strings or a single string; In the former case, each string will be a separate text block.
     The header block is a plain text header block.
-    The text blocks are markdown block of block type "section".
+    The text blocks have block type "section" and the text type is "mrkdwn" by default.
     """
     header_block = get_header_block(header_text)
     if isinstance(texts, str):

--- a/workspace/utils/blocks.py
+++ b/workspace/utils/blocks.py
@@ -6,3 +6,23 @@ def get_text_block(text, block_type="section", text_type="mrkdwn"):
             "text": text,
         },
     }
+
+
+def get_header_block(header_text, text_type="plain_text"):
+    return get_text_block(header_text, block_type="header", text_type=text_type)
+
+
+def get_basic_header_and_text_blocks(
+    header_text: str, texts: list | str, text_type="mrkdwn"
+):
+    """
+    Returns a list of blocks: a header block and text blocks with little room for customization.
+    "texts" can be a list of strings or a single string; In the former case, each string will be a separate text block.
+    The header block is a plain text header block.
+    The text blocks are markdown block of block type "section".
+    """
+    header_block = get_header_block(header_text)
+    if isinstance(texts, str):
+        texts = [texts]
+    text_blocks = [get_text_block(text, text_type=text_type) for text in texts]
+    return [header_block] + text_blocks

--- a/workspace/utils/blocks.py
+++ b/workspace/utils/blocks.py
@@ -24,5 +24,9 @@ def get_basic_header_and_text_blocks(
     header_block = get_header_block(header_text)
     if isinstance(texts, str):
         texts = [texts]
+    if len(texts) > 49:
+        raise ValueError(
+            f"""Slack has a limit of 50 blocks per message. Currently there are {len(texts)+1} blocks including the header block."""
+        )
     text_blocks = [get_text_block(text, text_type=text_type) for text in texts]
     return [header_block] + text_blocks

--- a/workspace/utils/rota.py
+++ b/workspace/utils/rota.py
@@ -2,7 +2,7 @@ import abc
 import json
 from datetime import date, timedelta
 
-from workspace.utils.blocks import get_text_block
+from workspace.utils.blocks import get_basic_header_and_text_blocks
 from workspace.utils.spreadsheets import get_data_from_sheet
 
 
@@ -17,24 +17,19 @@ class RotaReporter(abc.ABC):
 
     def report(self):
         rota = self.get_rota()
-        blocks = [self.get_header_block()]
 
         today = date.today()
         this_monday = today - timedelta(days=today.weekday())
-        blocks.append(
-            get_text_block(
-                self.get_rota_text_for_week(rota, this_monday, this_or_next="this")
-            )
-        )
-
         next_monday = this_monday + timedelta(days=7)
-        blocks.append(
-            get_text_block(
-                self.get_rota_text_for_week(rota, next_monday, this_or_next="next")
-            )
-        )
 
-        blocks.append(get_text_block(self.get_text_linking_rota_spreadsheet()))
+        blocks = get_basic_header_and_text_blocks(
+            header_text=self.title,
+            texts=[
+                self.get_rota_text_for_week(rota, this_monday, this_or_next="this"),
+                self.get_rota_text_for_week(rota, next_monday, this_or_next="next"),
+                self.get_text_linking_rota_spreadsheet(),
+            ],
+        )
         return json.dumps(blocks, indent=2)
 
     def get_rota(self):
@@ -47,9 +42,6 @@ class RotaReporter(abc.ABC):
         """
         Takes the rows returned from get_rota_data_from_sheet and converts them into a dictionary with dates as keys
         """
-
-    def get_header_block(self):
-        return get_text_block(self.title, block_type="header", text_type="plain_text")
 
     @abc.abstractmethod
     def get_rota_text_for_week(self, rota: dict, monday: date, this_or_next: str):


### PR DESCRIPTION
- A job can encounter no errors in its bash command execution but fail to post its results to Slack. This is a rare scenario but it can happen e.g. due to incorrect block formatting.
- Currently for such jobs the way to check the error is to go into the dispatcher logs
- Adding functionality for BennettBot to directly post the error into the chat
- In the process, utils functions for block formatting were created, which resulted in some refactoring done for other bits of code in the repo.