### PR TITLE
Fix typo in MessageChecker

### DIFF
--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -251,7 +251,7 @@ class MessageChecker:
         messages = self.user_slack_client.search_messages(
             query=(
                 # Search for messages with the keyword but without the expected reaction
-                f"{KeyboardInterrupt} -has::{reaction}: "
+                f"{keyword} -has::{reaction}: "
                 # exclude messages in the channel itself
                 f"-in:#{channel} "
                 # exclude messages from the bot

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -561,3 +561,11 @@ def test_message_checker_tech_support_messages(
     assert mock_client.recorder.mock_received_requests_kwargs["/reactions.add"] == [
         {"channel": "C4444", "name": reaction, "timestamp": "1709460000.0"}
     ]
+    mock_search.assert_called_once()
+    mock_search.assert_called_with(
+        query=(
+            f"{keyword} -has::{reaction}: -in:#{support_channel} "
+            f"-from:@{settings.SLACK_APP_USERNAME} -is:dm "
+            "before:2024-03-04 after:2024-03-02 "
+        )
+    )


### PR DESCRIPTION
Not sure how this got in - probably a VSCode autocomplete that somehow went unnoticed. Have also added the missing test assertions that would have caught it.