### PR TITLE
Notify users about suppressions (when scheduled, cancelled, or affecting deploy on PR merge)

### DIFF
--- a/ebmbot/bot.py
+++ b/ebmbot/bot.py
@@ -528,6 +528,10 @@ def handle_schedule_suppression(message, say, slack_config, _is_im):
         return
 
     scheduler.schedule_suppression(slack_config["job_type"], start_at, end_at)
+    say(
+        f"{slack_config['job_type']} suppressed from {start_at} to {end_at}",
+        thread_ts=message.get("ts"),
+    )
 
 
 @log_call
@@ -535,6 +539,10 @@ def handle_cancel_suppression(message, say, slack_config, _is_im):
     """Cancel a suppression."""
 
     scheduler.cancel_suppressions(slack_config["job_type"])
+    say(
+        f"{slack_config['job_type']} suppressions cancelled",
+        thread_ts=message.get("ts"),
+    )
 
 
 @log_call

--- a/ebmbot/dispatcher.py
+++ b/ebmbot/dispatcher.py
@@ -10,18 +10,16 @@ from multiprocessing import Process
 from pathlib import Path
 
 import requests
-from slack_sdk import WebClient
 
 from . import job_configs, scheduler, settings
 from .logger import logger
-from .slack import notify_slack
+from .slack import notify_slack, slack_web_client
 
 
 def run():  # pragma: no cover
     """Start the dispatcher and the message checker running."""
-    slack_client = WebClient(token=settings.SLACK_BOT_TOKEN)
-    user_slack_client = WebClient(token=settings.SLACK_BOT_USER_TOKEN)
-    checker = MessageChecker(slack_client, user_slack_client)
+    slack_client = slack_web_client(token_type="bot")
+    checker = MessageChecker(slack_client, slack_web_client(token_type="user"))
     checker.run_check()
     while True:
         run_once(slack_client, job_configs.config)

--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -1,9 +1,20 @@
 from time import sleep
 
+from slack_sdk import WebClient
+
 from ebmbot import settings
 from workspace.utils.blocks import get_basic_header_and_text_blocks, truncate_text
 
 from .logger import logger
+
+
+def slack_web_client(token_type="bot"):
+    token = (
+        settings.SLACK_BOT_TOKEN
+        if token_type == "bot"
+        else settings.SLACK_BOT_USER_TOKEN
+    )
+    return WebClient(token=token)
 
 
 def notify_slack(

--- a/ebmbot/slack.py
+++ b/ebmbot/slack.py
@@ -9,6 +9,13 @@ from .logger import logger
 
 
 def slack_web_client(token_type="bot"):
+    match token_type:
+        case "bot":
+            token = settings.SLACK_BOT_TOKEN
+        case "user":
+            token = settings.SLACK_BOT_USER_TOKEN
+        case _:
+            assert False, "Unknown token type"
     token = (
         settings.SLACK_BOT_TOKEN
         if token_type == "bot"

--- a/ebmbot/webserver/github.py
+++ b/ebmbot/webserver/github.py
@@ -6,6 +6,7 @@ from .. import scheduler, settings
 from ..job_configs import config
 from ..logger import logger
 from ..signatures import InvalidHMAC, validate_hmac
+from ..slack import notify_slack, slack_web_client
 
 
 def handle_github_webhook(project):
@@ -73,3 +74,25 @@ def schedule_deploy(project):
     logger.info("Scheduling deploy", project=project)
     channel = config["default_channel"][project]
     scheduler.schedule_job(job, {}, channel, "", delay_seconds=60)
+
+    # Notify if deploys are suppressed
+    active_suppression = next(
+        (
+            suppression
+            for suppression in scheduler.get_suppressions()
+            if suppression["start_at"] < str(scheduler._now())
+            and suppression["job_type"] == job
+        ),
+        None,
+    )
+    if active_suppression:
+        notify_slack(
+            slack_web_client(),
+            channel,
+            (
+                "PR merged, not deploying because deploys suppressed until "
+                f"{active_suppression['end_at']}.\n"
+                f"In an emergency, use `{project} suppress cancel` followed by "
+                f"`{project} deploy` to force a deployment"
+            ),
+        )

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch
 
 import httpretty
-from slack_sdk import WebClient
+import pytest
 
-from ebmbot.slack import notify_slack
+from ebmbot import settings
+from ebmbot.slack import notify_slack, slack_web_client
 from workspace.utils.blocks import get_text_block
 
 from .mock_http_request import get_mock_received_requests, httpretty_register
@@ -15,7 +16,7 @@ def test_notify_slack_success():
         {"chat.postMessage": [{"ok": True, "ts": 123.45, "channel": "test-channel"}]}
     )
 
-    notify_slack(WebClient(), "test-channel", "my message", 234.56)
+    notify_slack(slack_web_client(), "test-channel", "my message", 234.56)
     latest_requests = get_mock_received_requests()["/api/chat.postMessage"]
     assert len(latest_requests) == 1
     assert latest_requests[0] == {
@@ -32,7 +33,11 @@ def test_notify_slack_success_blocks():
     )
     block_message = [get_text_block(text="my message")]
     notify_slack(
-        WebClient(), "test-channel", block_message, 234.56, message_format="blocks"
+        slack_web_client(),
+        "test-channel",
+        block_message,
+        234.56,
+        message_format="blocks",
     )
     latest_requests = get_mock_received_requests()["/api/chat.postMessage"]
     assert len(latest_requests) == 1
@@ -54,7 +59,9 @@ def test_notify_slack_retries():
         {"chat.postMessage": [{"ok": False, "error": "error"}, {"ok": True}]}
     )
 
-    notify_slack(WebClient(), "test-channel", "my message", 234.56, retry_delay=0.1)
+    notify_slack(
+        slack_web_client(), "test-channel", "my message", 234.56, retry_delay=0.1
+    )
     latest_requests = get_mock_received_requests()["/api/chat.postMessage"]
     assert len(latest_requests) == 2
     # both attempted calls are with the original message (first errors, second succeeds)
@@ -77,7 +84,9 @@ def test_notify_slack_retries_fallback():
         {"chat.postMessage": [{"ok": False, "error": "error"}, {"ok": True}]}
     )
 
-    notify_slack(WebClient(), "test-channel", "my message", 234.56, retry_delay=0.1)
+    notify_slack(
+        slack_web_client(), "test-channel", "my message", 234.56, retry_delay=0.1
+    )
     latest_requests = get_mock_received_requests()["/api/chat.postMessage"]
     assert len(latest_requests) == 2
 
@@ -100,7 +109,9 @@ def test_notify_slack_retries_fallback_error():
     # The fallback (second mocked response) also errors, so we give up and just log
     httpretty_register({"chat.postMessage": [{"ok": False, "error": "error"}]})
 
-    notify_slack(WebClient(), "test-channel", "my message", 234.56, retry_delay=0.1)
+    notify_slack(
+        slack_web_client(), "test-channel", "my message", 234.56, retry_delay=0.1
+    )
     latest_requests = get_mock_received_requests()["/api/chat.postMessage"]
     assert len(latest_requests) == 3
 
@@ -114,3 +125,24 @@ def test_notify_slack_retries_fallback_error():
         }
     # 3rd call with failure message also errors
     assert latest_requests[2]["text"] == "Could not notify slack"
+
+
+@pytest.mark.parametrize(
+    "token_type,token",
+    [
+        ("bot", settings.SLACK_BOT_TOKEN),
+        ("user", settings.SLACK_BOT_USER_TOKEN),
+        (None, settings.SLACK_BOT_TOKEN),
+    ],
+)
+def test_slack_client(token_type, token):
+    if token_type:
+        client = slack_web_client(token_type)
+    else:
+        client = slack_web_client()
+    assert client.token == token
+
+
+def test_slack_client_with_bad_token_type():
+    with pytest.raises(AssertionError, match="Unknown token type"):
+        slack_web_client("unk")


### PR DESCRIPTION
Fixes #6 
Depends on #576 

Notify in slack when a PR is merged and deploys are suppressed. This currently only applies (I think) to OpenPrescribing, which uses the webserver as a callback when PRs are merged to main. BennettBot will schedule a deploy job, however if there is already a deploy suppression in place, it looks like nothing has happened. (You could call @BennettBot status to see that the job is scheduled and the suppression is active, but that's not obvious).

Now we post a message (in the job's default channel, which is usually #tech-noise for these sorts of things) to notify the user.

Also adds confirmation messages for scheduling and cancelling suppressions, as those both respond with :crossed_fingers: as with other jobs, but don't give any other indication that they've actually done something.