### PR TITLE
Remove #TODO and minor change in help message

### DIFF
--- a/ebmbot/job_configs.py
+++ b/ebmbot/job_configs.py
@@ -317,7 +317,7 @@ raw_config = {
             {
                 "command": "show [target]",
                 # There is a line break in this help message because it's too long and this is the only action in the workspace so it doesn't look ugly anyway.
-                "help": "Summarise GitHub Actions workflow runs for a given `target` organisation or repo, provided in the form of `org` or `org/repo`. \n`org` is limited to the following shorthands and their full names: `os (opensafely)`, `osc (opensafely-core)`, `ebm (ebmdatalab)`.",
+                "help": "Summarise GitHub Actions workflow runs for a given `target` organisation or repo, provided in the form of `org` or `org/repo`. \n(Note: `org` is limited to the following shorthands and their full names: `os (opensafely)`, `osc (opensafely-core)`, `ebm (ebmdatalab)`.)",
                 "action": "schedule_job",
                 "job_type": "show",
             },

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -26,7 +26,6 @@ def report_invalid_org(org):
     return json.dumps(blocks)
 
 
-# TODO:Make this a shared function
 def get_api_result_as_json(url: str, params: dict | None = None) -> dict:
     params = params or {}
     params["format"] = "json"


### PR DESCRIPTION
I left a TODO comment thinking that I can share some code between `workflows/jobs.py` and `report/generate_report.py`, but the differences between what's being done is actually larger than I thought, so I'm getting rid of the comment. 

Also tiny improvement to the help message so that `org` doesn't look like a command. 