### PR TITLE
Add ethelred to workflow reporting config

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -2,6 +2,7 @@ TEAMS = [
     "Tech shared",
     "Team REX",
     "Team RAP",
+    "Team PIN",
 ]
 
 REPOS = {
@@ -32,6 +33,10 @@ REPOS = {
     "ehrql": {
         "org": "opensafely-core",
         "team": "Team RAP",
+    },
+    "ethelred": {
+        "org": "opensafely-core",
+        "team": "Team PIN",
     },
     "job-runner": {
         "org": "opensafely-core",


### PR DESCRIPTION
We would like to report the build status of ethelred in our daily dashboards. 
Also add Team PIN as the responsible team!

(Rewrote commit message and rebased since it turns out I can't spell ethelred ...)