### PR TITLE
Disable minimumReleaseAge for pinDigest update types

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -102,6 +102,13 @@
         "* 0-3 * * WED"
       ]
     },
+    // disable minimumReleaseAge for pinDigest to avoid the stability-days check showing as pending
+    // when Renovate opens a PR for pinning GHA dependencies to digests
+    {
+      "description": "Disable minimumReleaseAge for pinDigest update types",
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null,
+    },
     // EXAMPLE: If required, pin a specific dependency to an upper allowed version
     // Otherwise renovate will use the general "widen" strategy to change the upper limit in pyproject.toml
     // and will bump it anyway


### PR DESCRIPTION
minimumReleaseAge is [not supported](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account) for "pinDigest" update types. 

[Opting out](https://docs.renovatebot.com/key-concepts/minimum-release-age/#how-do-i-opt-out-dependencies-from-minimum-release-age-checks) of it for pinDigest update types should prevent the forever-pending status on PRs like the one to [pin dependencies for GHAs](https://github.com/bennettoxford/bennettbot/pull/853), which is trying to pin all GHA to digests 

