### PR TITLE
Ignore extraneous whitespace in rota reports

### DIFF
--- a/tests/workspace/test_outputchecking_rota.py
+++ b/tests/workspace/test_outputchecking_rota.py
@@ -114,3 +114,32 @@ def test_rota_report_missing_future_dates(get_rota_data_from_sheet, freezer):
             },
         },
     ]
+
+
+@patch(
+    "workspace.outputchecking.jobs.OutputCheckingRotaReporter.get_rota_data_from_sheet"
+)
+def test_rota_report_ignores_surrounding_whitespace(get_rota_data_from_sheet, freezer):
+    freezer.move_to("2023-02-20")
+    get_rota_data_from_sheet.return_value = [
+        ["Week commencing", "Lead reviewer", "Reviewer 2"],
+        ["  2023-02-20", "Louis Fisher ", "Colm Andrews "],
+        ["2023-02-27  ", "Jon Massey ", " Lisa Hopcroft"],
+    ]
+    blocks = json.loads(report_rota())
+    assert blocks[1:3] == [
+        {
+            "text": {
+                "text": "Lead reviewer this week (20 Feb-24 Feb): Louis Fisher (secondary: Colm Andrews)",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "text": {
+                "text": "Lead reviewer next week (27 Feb-03 Mar): Jon Massey (secondary: Lisa Hopcroft)",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+    ]

--- a/workspace/utils/rota.py
+++ b/workspace/utils/rota.py
@@ -64,6 +64,7 @@ class SpreadsheetRotaReporter(RotaReporter):
 
     def get_rota(self):
         rows = self.get_rota_data_from_sheet()
+        rows = [[v.strip() for v in row] for row in rows]
         rota = self.convert_rota_data_to_dictionary(rows)
         return rota
 


### PR DESCRIPTION
We had a situation where we ended up with leading whitespace on dates in a sheet (possibly an error in a custom date format?) which broke the rota report in an annoying to debug way. It would be better to be robust against this kind of stuff.

See related Slack thread:
https://bennettoxford.slack.com/archives/C02HJTL065A/p1775462418167209
