### PR TITLE
Lockfile updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,47 @@
+name: Lockfile maintenance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "0 4 * * WED"
+
+permissions:
+  contents: read
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v6
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        install-just: true
+        install-uv: true
+        cache: uv
+
+    - uses: actions/create-github-app-token@v2
+      id: generate-token
+      with:
+        app-id: ${{ vars.CREATE_PR_APP_ID }}
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+
+    - uses: bennettoxford/update-dependencies-action@bdea909f667cfe51dae1e062ae04b7e644f60166  # v1
+      id: update
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
+        pr_title: uv lockfile maintentance
+        pr_body: |
+          :information_source: Before reviewing this PR, merge any Renovate prod/dev/security dependency PRs and rebase.
+          This will ensure that this PR handles transitive dependencies only.
+
+          Automated changes by [update-dependencies-action](https://github.com/bennettoxford/update-dependencies-action)
+
+    - name: Notify slack of PR
+      if: ${{ steps.update.outputs.pull-request-operation != 'none' }}
+      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+      with:
+        method: chat.postMessage
+        token: ${{ secrets.BENNETTBOT_SLACK_BOT_TOKEN }}
+        payload: |
+          channel: "C080S7W2ZPX"
+          text: "Update dependencies\n${{ steps.update.outputs.pull-request-url }}"

--- a/justfile
+++ b/justfile
@@ -57,9 +57,9 @@ install-precommit:
 upgrade-package package: devenv
     uv lock --upgrade-package {{ package }}
 
-# recipe is only used if we want upgrade packages outside of dependabot
-upgrade-all: devenv
-    uv lock --upgrade
+# recipe is used for doing lockfileMaintenance via update-dependencies action, until min release age is respected fo uv
+upgrade-all cooldown="7 days ago": devenv
+    uv lock --upgrade --exclude-newer "{{ cooldown }}"
 
 # update the companion requirements formatted file
 uvmirror file="requirements.uvmirror":

--- a/justfile
+++ b/justfile
@@ -66,6 +66,8 @@ uvmirror file="requirements.uvmirror":
     rm -f {{ file }}
     uv export --format requirements-txt --frozen --no-hashes --all-groups --all-extras > {{ file }}
 
+update-dependencies: upgrade-all && uvmirror
+
 # *ARGS is variadic, 0 or more. This allows us to do `just test -k match`, for example.
 
 # Run the tests

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,18 +21,25 @@
   ],
   // Label all Reonvate PRs with "dependencies"
   "labels": ["dependencies"],
+  //
+  // NOTE: lockFileMaintenance is currently disabled as it doesn't respect the
+  // minimumReleaseAge for uv. An open PR for adding it has been put on hold for now.
+  // https://github.com/renovatebot/renovate/pull/41913#issuecomment-4231423178
+  // Instead, for now we use the update-dependencies-action to update the
+  // uv lockfile
+  "lockFileMaintenance": { "enabled": false},
   // update transitive deps by updating the entire lockfile
   // We run this on the same schedule; add a note for the reviewer to do the
   // default dependencies first to reduce the amount needed for review in the
   // full lockfile update
-  "lockFileMaintenance": {
-      "enabled": true,
-      "minimumReleaseAge": "7 days",
-      "schedule": [
-        "* 0-3 * * WED"
-      ],
-      "prBodyNotes": [":information_source: Before reviewing this PR, merge any prod/dev dependency PRs and rebase."]
-  },
+  // "lockFileMaintenance": {
+  //     "enabled": true,
+  //     "minimumReleaseAge": "7 days",
+  //     "schedule": [
+  //       "* 0-3 * * WED"
+  //     ],
+  //     "prBodyNotes": [":information_source: Before reviewing this PR, merge any prod/dev dependency PRs and rebase."]
+  // },
   // don't auto-update python-version, we want to manage python updates ourselves
   "ignorePaths": [".python-version"],
   // Note package rules apply only to direct dependencies


### PR DESCRIPTION
Disable lockFileMaintenance is as it doesn't currently respect the minimumReleaseAge for uv. An [open PR](https://github.com/renovatebot/renovate/pull/41913#issuecomment-4231423178) for adding it has been put on hold for now.
    
Instead, we use the update-dependencies-action to update the uv lockfile with a 7 day cooldown (and a custom PR description to remind you to merge renovate PRs and rebase first)
