### PR TITLE
Ignore sql-runner dependabot workflow in report

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -143,7 +143,7 @@ IGNORED_WORKFLOWS = {
         21967294,  # [On PR] Dependabot auto-approve and enable auto-merge
     ],
     "opensafely-core/sqlrunner": [
-        37329087,  # [On PR] Auto merge Dependabot PRs
+        108481072,  # [Removed] Dependabot Updates
     ],
     "bennettoxford/bennettbot": [
         32719413,  # [On PR] Auto merge Dependabot PRs


### PR DESCRIPTION
This workflow has been removed, but since the API still provides data for its last run, the workflows report includes it.

Normally this is fine as we only fetch the last 1000 runs of a repo and obsolete workflows will eventually not get included, but since the last run is a failing run, we want to hide it from the report immediately to avoid confusion.