### PR TITLE
Fix the message checker to use the same terms as the support listeners

### DIFF
--- a/bennettbot/bot.py
+++ b/bennettbot/bot.py
@@ -111,10 +111,10 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
     """
     support_config = get_support_config(channels)
     # Check that channel settings mapped to valid channel IDs
-    for support in support_config.values():
+    for support_type, support in support_config.items():
         if support["support_channel"] not in channels.values():
             raise ValueError(
-                f"{support['keyword']} channel id '{support['support_channel']}' not found"
+                f"{support_type} channel id '{support['support_channel']}' not found"
             )
 
     @app.event(
@@ -259,7 +259,11 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
     )
     def repost_to_bennett_admins(event, say, ack):
         repost_support_request_to_channel(
-            event, say, ack, **support_config["bennett-admins"]
+            event,
+            say,
+            ack,
+            support_type="bennett-admins",
+            **support_config["bennett-admins"],
         )
 
     @app.event(
@@ -268,11 +272,15 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
     )
     def repost_to_tech_support(event, say, ack):
         repost_support_request_to_channel(
-            event, say, ack, **support_config["tech-support"]
+            event,
+            say,
+            ack,
+            support_type="tech-support",
+            **support_config["tech-support"],
         )
 
     def repost_support_request_to_channel(
-        event, say, ack, *, keyword, reaction, support_channel, **kwargs
+        event, say, ack, *, support_type, reaction, support_channel, **kwargs
     ):
         # acknowledge the messages
         ack()
@@ -294,8 +302,8 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
             app.client.reactions_add(
                 channel=channel, timestamp=message["ts"], name=reaction
             )
-            logger.info(f"Received {keyword} message", message=message["text"])
-            if keyword == "tech-support":
+            logger.info(f"Received {support_type} message", message=message["text"])
+            if support_type == "tech-support":
                 # If out of office, respond with an ooo message, but still repost to channel
                 out_of_office_until = tech_support_out_of_office()
                 if out_of_office_until:
@@ -312,7 +320,7 @@ def register_listeners(app, config, channels, bot_user_id, internal_user_ids):
             say(message_url, channel=support_channel)
         else:
             say(
-                f"Sorry, I can't call {keyword} from this conversation.",
+                f"Sorry, I can't call {support_type} from this conversation.",
                 channel=channel,
             )
 

--- a/bennettbot/config.py
+++ b/bennettbot/config.py
@@ -7,7 +7,8 @@ def get_support_config(channels=None):
     channels = channels or {}
     return {
         "tech-support": {
-            "keyword": "tech-support",
+            # list keywords; needed for the MessageChecker search
+            "search_keywords": ["tech-support"],
             # Use the support setting (a channel name or channel ID) to get the channel.
             # We first attempt to retrieve channel ID from the channels dict (if provided),
             # otherwise we default to using the setting value as is.
@@ -20,7 +21,9 @@ def get_support_config(channels=None):
             "reaction": "sos",
         },
         "bennett-admins": {
-            "keyword": "bennett-admins",
+            # list keywords; needed for the MessageChecker search. Note we only need to
+            # list the singular as it's contained in the plurals
+            "search_keywords": ["bennet-admin", "bennett-admin"],
             # Use the support setting (a channel name or channel ID) to get the channel.
             # We first attempt to retrieve channel ID from the channels dict (if provided),
             # otherwise we default to using the setting value as is.

--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -241,34 +241,45 @@ class MessageChecker:
             # make sure that messages sent late in the day still get picked up
             today = datetime.today()
             check_from = (today - timedelta(days=2)).strftime("%Y-%m-%d")
-            for keyword in self.config:
-                self.check_messages(keyword, check_from)
+            for support_type in self.config:
+                self.check_messages(support_type, check_from)
             time.sleep(delay)
 
-    def check_messages(self, keyword, after):
-        logger.debug("Checking %s messages", keyword)
-        reaction = self.config[keyword]["reaction"]
-        channel = self.config[keyword]["support_channel"]
-        messages = self.user_slack_client.search_messages(
-            query=(
-                # Search for messages with the keyword but without the expected reaction
-                # Wrap the keyword in double quotes so we don't return "tech support" as
-                # well as "tech-support"
-                f'"{keyword}" -has::{reaction}: '
-                # exclude messages in the channel itself
-                f"-in:#{channel} "
-                # exclude messages from the bot
-                f"-from:@{settings.SLACK_APP_USERNAME} "
-                # exclude DMs as the auto-responders don't respond to these anyway
-                f"-is:dm "
-                # only include messages from today and yesterday
-                f"after:{after}"
+    def check_messages(self, support_type, after):
+        logger.debug("Checking %s messages", support_type)
+        reaction = self.config[support_type]["reaction"]
+        channel = self.config[support_type]["support_channel"]
+        keywords = self.config[support_type]["search_keywords"]
+        regex = self.config[support_type]["regex"]
+
+        messages = []
+        for keyword in keywords:
+            messages.extend(
+                self.user_slack_client.search_messages(
+                    query=(
+                        # Search for messages with the keyword but without the expected reaction
+                        # Wrap the keyword in double quotes so we don't return "tech support" as
+                        # well as "tech-support"
+                        f'"{keyword}" -has::{reaction}: '
+                        # exclude messages in the channel itself
+                        f"-in:#{channel} "
+                        # exclude messages from the bot
+                        f"-from:@{settings.SLACK_APP_USERNAME} "
+                        # exclude DMs as the auto-responders don't respond to these anyway
+                        f"-is:dm "
+                        # only include messages from today and yesterday
+                        f"after:{after}"
+                    )
+                )["messages"]["matches"]
             )
-        )["messages"]["matches"]
+
+        handled = []
         for message in messages:
+            if message in handled:
+                continue
+            handled.append(message)
             # remove any URLs from the message text; we don't want to match these
-            text = re.sub(r"<http.+>", "", message["text"])
-            if keyword not in text:
+            if not re.match(regex, message["text"]):
                 # Either the message contained the keyword in a URL only (and we've
                 # just removed it), or it didn't contain the keyword at all.
                 # The latter happens if it's a forwarded message or a copy/pasted link.

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -10,6 +10,7 @@ from mocket import Mocket, Mocketizer
 from mocket.mockhttp import Entry
 
 from bennettbot import scheduler, settings
+from bennettbot.config import get_support_config
 from bennettbot.dispatcher import JobDispatcher, MessageChecker, run_once
 from bennettbot.slack import slack_web_client
 
@@ -565,50 +566,65 @@ def test_message_checker_run(freezer):
     run_fn = Mock(side_effect=[True, True, False])
     checker.do_check(run_fn, delay=0.1)
 
-    # search.messages is called twice for each run of the checker
+    # search.messages is called once per search keyword for each
+    # run of the checker (mocked above to run only 2x)
     # no matches, so no reactions or messages reposted.
-    assert len(Mocket.request_list()) == 4
+    total_search_keywords = sum(
+        len(support_config["search_keywords"])
+        for support_config in get_support_config().values()
+    )
+    assert len(Mocket.request_list()) == 2 * total_search_keywords
     requests_by_path = get_mock_received_requests()
     last_search_query = requests_by_path["/api/search.messages"][-1]["query"][0]
     assert "after:2024-10-06" in last_search_query
 
 
 @pytest.mark.parametrize(
-    "keyword,support_channel,reaction",
+    "support_type,support_channel,reaction",
     (
         ["tech-support", settings.SLACK_TECH_SUPPORT_CHANNEL, "sos"],
         ["bennett-admins", settings.SLACK_BENNETT_ADMINS_CHANNEL, "flamingo"],
     ),
 )
-def test_message_checker_matched_messages(keyword, support_channel, reaction):
+def test_message_checker_matched_messages(support_type, support_channel, reaction):
+    support_config = get_support_config()
+    keywords = support_config[support_type]["search_keywords"]
+
+    mock_matches = [
+        {
+            "text": "This is a forwarded message",
+            "channel": {"id": "C4444"},
+            "ts": "100.1",
+        }
+    ]
+    for keyword in keywords:
+        mock_matches.extend(
+            [
+                {
+                    "text": f"Calling {keyword}",
+                    "channel": {"id": "C4444"},
+                    "ts": "100.0",
+                },
+                {
+                    "text": f"Ignore message with url matches only <https://calling/{keyword}/test>",
+                    "channel": {"id": "C4444"},
+                    "ts": "100.2",
+                },
+                {
+                    "text": f"But respond if {keyword} is also in the text <https://calling/{keyword}/test>",
+                    "channel": {"id": "C4444"},
+                    "ts": "100.3",
+                },
+            ]
+        )
+
     mocket_register(
         {
             "search.messages": [
                 {
                     "ok": True,
                     "messages": {
-                        "matches": [
-                            {
-                                "text": f"Calling {keyword}",
-                                "channel": {"id": "C4444"},
-                                "ts": "100.0",
-                            },
-                            {
-                                "text": "This is a forwarded message",
-                                "channel": {"id": "C4444"},
-                                "ts": "100.1",
-                            },
-                            {
-                                "text": f"Ignore message with url matches only <https://calling/{keyword}/test>",
-                                "channel": {"id": "C4444"},
-                                "ts": "100.2",
-                            },
-                            {
-                                "text": f"But respond if {keyword} is also in the text <https://calling/{keyword}/test>",
-                                "channel": {"id": "C4444"},
-                                "ts": "100.3",
-                            },
-                        ],
+                        "matches": mock_matches,
                     },
                 }
             ],
@@ -618,11 +634,11 @@ def test_message_checker_matched_messages(keyword, support_channel, reaction):
 
     checker = MessageChecker(slack_web_client("bot"), slack_web_client("user"))
 
-    checker.check_messages(keyword, "2024-03-02")
-    # search.messages is called once
-    # other 3 endpoints called once each for 2 matched messages requiring
+    checker.check_messages(support_type, "2024-03-02")
+    # search.messages is called once per keyword
+    # other 3 endpoints called once each for 2 matched messages per keyword requiring
     # reaction and reposting.
-    assert len(Mocket.request_list()) == 7
+    assert len(Mocket.request_list()) == len(keywords) + (3 * 2 * len(keywords))
 
     requests_by_path = get_mock_received_requests()
     assert requests_by_path["/api/search.messages"] == [
@@ -633,6 +649,7 @@ def test_message_checker_matched_messages(keyword, support_channel, reaction):
                 "after:2024-03-02"
             ]
         }
+        for keyword in keywords
     ]
     # fetch the permalink for the message with ts matching the message to be reposted
     assert requests_by_path["/api/chat.getPermalink"] == [
@@ -644,16 +661,19 @@ def test_message_checker_matched_messages(keyword, support_channel, reaction):
             "channel": ["C4444"],
             "message_ts": ["100.3"],
         },
-    ]
-    # reposted to correct channel
-    assert requests_by_path["/api/chat.postMessage"][0] == {
-        "channel": support_channel,
-        "text": "http://example.com",
-    }
-    assert requests_by_path["/api/chat.postMessage"][1] == {
-        "channel": support_channel,
-        "text": "http://example.com",
-    }
+    ] * len(keywords)
+    # reposted to correct channel for each message/keyword
+    assert (
+        requests_by_path["/api/chat.postMessage"]
+        == [
+            {
+                "channel": support_channel,
+                "text": "http://example.com",
+            }
+        ]
+        * len(keywords)
+        * 2
+    )
 
     # reacted with correct emoji
     assert requests_by_path["/api/reactions.add"] == [
@@ -667,7 +687,7 @@ def test_message_checker_matched_messages(keyword, support_channel, reaction):
             "name": [reaction],
             "timestamp": ["100.3"],
         },
-    ]
+    ] * len(keywords)
 
 
 def test_python_version():


### PR DESCRIPTION
Updates the message checker to respond to the same terms as the bot listener. The message checker looks for support request messages that haven't already been acknowledged. Previously it was only using a single simple keyword, which missed the allowed typos (bennet-admin etc) and also over-matched on terms that it shouldn't (e.g. it picked up
a mention of "tech-support-channel" that had been correctly ignored by the listener). We now search by a list of search keywords, and apply the same regex that the bot listener uses to work out if it's a message that needs to be reposted to the support channel.
