### PR TITLE
Add jobs to report on Dependabot security alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each key in `raw_config` refers to a category of jobs (the job namespace), and m
             "report_stdout": boolean, default=False,  # whether to report contents of stdout to slack
             "report_success": boolean, default=True,  # whether to report success to slack
             "report_format": "text/blocks/code/file",  # format of slack report, plain text, blocks, code or file upload (default="text")
+            "suppress_empty": boolean, default=False,  # if True and stdout is empty, post nothing to slack (instead of the default "No output found" message); useful for scheduled check-style jobs that should only ping when there's something to report
         }
     }
     "slack": [

--- a/bennettbot/bot.py
+++ b/bennettbot/bot.py
@@ -536,6 +536,7 @@ def handle_schedule_job(message, say, slack_config, is_im=False):
         thread_ts=message.get("thread_ts"),
         delay_seconds=slack_config["delay_seconds"],
         is_im=is_im,
+        message_ts=message.get("ts"),
     )
     if existing_job_is_running:
         say(

--- a/bennettbot/connection.py
+++ b/bennettbot/connection.py
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS job (
     args TEXT,
     channel TEXT,
     thread_ts TEXT,
+    message_ts TEXT,
     start_after DATETIME,
     started_at DATETIME,
     is_im BOOLEAN
@@ -33,4 +34,8 @@ def get_connection():
     conn = sqlite3.connect(settings.DB_PATH)
     conn.row_factory = dict_factory
     conn.executescript(SCHEMA)
+    # Migration: ensure message_ts column exists on pre-existing job tables.
+    existing_cols = {row["name"] for row in conn.execute("PRAGMA table_info(job)")}
+    if "message_ts" not in existing_cols:
+        conn.execute("ALTER TABLE job ADD COLUMN message_ts TEXT")
     return conn

--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -128,6 +128,10 @@ class JobDispatcher:
         required."""
 
         error = rc != 0
+        # React to the requesting Slack message first, before the various
+        # early-returns below - we want the completion signal regardless of
+        # which branch we end up taking.
+        self.react_to_requesting_message("x" if error else "white_check_mark")
         repost_to_tech_support_on_error = (
             # Call tech-support unless specified otherwise in the job config
             # But not if we're in a DM with the bot, because no-one
@@ -183,6 +187,24 @@ class JobDispatcher:
             self.slack_client.chat_postMessage(
                 channel=settings.SLACK_TECH_SUPPORT_CHANNEL, text=message_url
             )
+
+    def react_to_requesting_message(self, emoji):
+        """Add an emoji reaction to the Slack message that triggered this job."""
+        message_ts = self.job.get("message_ts")
+        if not message_ts:
+            # Note that jobs might not have an originating message (e.g scheduled/automated
+            # runs that call schedule_job() directly, without going via the bot.py. The
+            # main example of this is the webhook in webserver/github.py which schedules
+            # project deploys via callbacks from GitHub).
+            return
+        try:
+            # Note: reacting to the original message isn't the most important thing; if
+            # something goes wrong here, we don't really care, so just swallow any error
+            self.slack_client.reactions_add(
+                channel=self.job["channel"], timestamp=message_ts, name=emoji
+            )
+        except Exception:  # pragma: no cover
+            logger.exception("Failed to add reaction", emoji=emoji)
 
     def set_up_cwd(self):
         """Ensure cwd exists, and maybe refresh fabfile."""

--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -136,13 +136,21 @@ class JobDispatcher:
         )
         if not error:
             if self.job_config["report_stdout"]:
-                with open(self.stdout_path) as f:
-                    if self.job_config["report_format"] == "blocks":
-                        msg = json.load(f)
-                    else:
-                        msg = f.read()
-                    if not msg:
-                        msg = f"No output found for command `{self.job['type']}`"
+                content = self.stdout_path.read_text()
+                if self.job_config["report_format"] == "blocks":
+                    # a suppress_empty job legitimately produces no stdout
+                    # when there's nothing to report, so only load json if there's
+                    # content to load.
+                    msg = json.loads(content) if content.strip() else None
+                else:
+                    msg = content
+                if not msg:
+                    # Empty stdout (or empty blocks array): suppress_empty
+                    # jobs stay silent; everything else falls back
+                    # to a placeholder message so the channel sees something.
+                    if self.job_config.get("suppress_empty"):
+                        return
+                    msg = f"No output found for command `{self.job['type']}`"
             elif self.job_config["report_success"]:
                 msg = f"Command `{self.job['type']}` succeeded"
             else:

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -702,19 +702,24 @@ def get_template_params(command, wrapper="[]"):
 def validate_job_config(job_type, job_config):
     """Validate that job_config contains expected keys."""
 
-    expected_keys = {
+    # Required keys are defaulted in build_config() above, so every
+    # built job_config dict ends up with all of them. Optional keys are
+    # left absent unless the job explicitly opts in - they don't appear
+    # in the built config dict otherwise, keeping it tidy.
+    required_keys = {
         "run_args_template",
         "report_stdout",
         "report_format",
         "report_success",
         "call_tech_support_on_error",
     }
+    optional_keys = {"suppress_empty"}
 
-    if missing_keys := (expected_keys - job_config.keys()):
+    if missing_keys := (required_keys - job_config.keys()):
         msg = f"Job {job_type} is missing keys {missing_keys}"
         raise RuntimeError(msg)
 
-    if extra_keys := (job_config.keys() - expected_keys):
+    if extra_keys := (job_config.keys() - required_keys - optional_keys):
         msg = f"Job {job_type} has extra keys {extra_keys}"
         raise RuntimeError(msg)
 

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -413,6 +413,92 @@ raw_config = {
             },
         ]
     },
+    "security": {
+        "restricted": True,
+        "description": "Report open critical/high severity Dependabot alerts",
+        "jobs": {
+            "display_usage": {
+                "run_args_template": "python jobs.py usage",
+                "report_stdout": True,
+            },
+            "report": {
+                "run_args_template": "python jobs.py report --target {target}",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+            "report_all_targets": {
+                "run_args_template": "python jobs.py report",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+            "check": {
+                "run_args_template": "python jobs.py report --target {target} --quiet",
+                "report_stdout": True,
+                "report_format": "blocks",
+                "suppress_empty": True,
+            },
+            "check_all_targets": {
+                "run_args_template": "python jobs.py report --quiet",
+                "report_stdout": True,
+                "report_format": "blocks",
+                "suppress_empty": True,
+            },
+            "report_all_severities": {
+                "run_args_template": "python jobs.py report --target {target} --all-severities",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+            "report_all_severities_all_targets": {
+                "run_args_template": "python jobs.py report --all-severities",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+        },
+        "slack": [
+            {
+                "command": "usage",
+                "help": "Show help message for the `report` and `check` commands.",
+                "action": "schedule_job",
+                "job_type": "display_usage",
+            },
+            {
+                "command": "report",
+                "help": "Report on open critical/high security alerts for all monitored repos, by team.",
+                "action": "schedule_job",
+                "job_type": "report_all_targets",
+            },
+            {
+                "command": "report [target]",
+                "help": "Report on open critical/high security alerts for `target` (team, org, or repo). See `security usage` for valid values.",
+                "action": "schedule_job",
+                "job_type": "report",
+            },
+            {
+                "command": "check",
+                "help": "Like `report`, but does not post anything if there are no alerts to report.",
+                "action": "schedule_job",
+                "job_type": "check_all_targets",
+            },
+            {
+                "command": "check [target]",
+                "help": "Like `report [target]`, but does not post anything if there are no alerts to report.",
+                "action": "schedule_job",
+                "job_type": "check",
+            },
+            {
+                "command": "report-all",
+                "help": "Like `report`, but also reports on alerts for all levels of severity.",
+                "action": "schedule_job",
+                "job_type": "report_all_severities_all_targets",
+            },
+            {
+                "command": "report-all [target]",
+                "help": "Like `report [target]`, but reports on alerts for all levels of severity.",
+                "action": "schedule_job",
+                "job_type": "report_all_severities",
+            },
+        ]
+    },
     "techsupport": {
         "restricted": True,
         "description": "Tech Support out of office and rota",

--- a/bennettbot/scheduler.py
+++ b/bennettbot/scheduler.py
@@ -7,7 +7,9 @@ from .logger import log_call
 
 
 @log_call
-def schedule_job(type_, args, channel, thread_ts, delay_seconds, is_im=False):
+def schedule_job(
+    type_, args, channel, thread_ts, delay_seconds, is_im=False, message_ts=None
+):
     """Schedule job to be run.
 
     Only one job of any type may be scheduled.  If a job is already scheduled
@@ -15,6 +17,10 @@ def schedule_job(type_, args, channel, thread_ts, delay_seconds, is_im=False):
     record of the first job is updated.
 
     If a job is already running, another job of that type may be scheduled.
+
+    `message_ts` is the timestamp of the Slack message that triggered the job,
+    so the dispatcher can react to it on completion. May be None for
+    automated/scheduled jobs that have no originating message.
 
     Returns a boolean indicating whether an existing job was already running.
     """
@@ -34,40 +40,53 @@ def schedule_job(type_, args, channel, thread_ts, delay_seconds, is_im=False):
             existing_jobs = list(conn.execute(sql, [type_]))
         existing_job_running = False
         if len(existing_jobs) == 0:
-            _create_job(conn, type_, args, channel, thread_ts, start_after, is_im)
+            _create_job(
+                conn, type_, args, channel, thread_ts, message_ts, start_after, is_im
+            )
         elif len(existing_jobs) == 1:
             job = existing_jobs[0]
             if job["has_started"]:
                 existing_job_running = True
-                _create_job(conn, type_, args, channel, thread_ts, start_after, is_im)
+                _create_job(
+                    conn,
+                    type_,
+                    args,
+                    channel,
+                    thread_ts,
+                    message_ts,
+                    start_after,
+                    is_im,
+                )
             else:
                 id_ = job["id"]
-                _update_job(conn, id_, args, channel, thread_ts, start_after)
+                _update_job(
+                    conn, id_, args, channel, thread_ts, message_ts, start_after
+                )
         elif len(existing_jobs) == 2:
             assert not existing_jobs[0]["has_started"]
             assert existing_jobs[1]["has_started"]
             existing_job_running = True
             id_ = existing_jobs[0]["id"]
-            _update_job(conn, id_, args, channel, thread_ts, start_after)
+            _update_job(conn, id_, args, channel, thread_ts, message_ts, start_after)
         else:
             assert False
 
     return existing_job_running
 
 
-def _create_job(conn, type_, args, channel, thread_ts, start_after, is_im):
+def _create_job(conn, type_, args, channel, thread_ts, message_ts, start_after, is_im):
     with conn:
         conn.execute(
-            "INSERT INTO job (type, args, channel, thread_ts, start_after, is_im) VALUES (?, ?, ?, ?, ?, ?)",
-            [type_, args, channel, thread_ts, start_after, is_im],
+            "INSERT INTO job (type, args, channel, thread_ts, message_ts, start_after, is_im) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [type_, args, channel, thread_ts, message_ts, start_after, is_im],
         )
 
 
-def _update_job(conn, id_, args, channel, thread_ts, start_after):
+def _update_job(conn, id_, args, channel, thread_ts, message_ts, start_after):
     with conn:
         conn.execute(
-            "UPDATE job SET args = ?, channel = ?, thread_ts = ?, start_after = ? WHERE id = ?",
-            [args, channel, thread_ts, start_after, id_],
+            "UPDATE job SET args = ?, channel = ?, thread_ts = ?, message_ts = ?, start_after = ? WHERE id = ?",
+            [args, channel, thread_ts, message_ts, start_after, id_],
         )
 
 

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -64,6 +64,11 @@ raw_config = {
                 "run_args_template": "python jobs.py hello_world_no_output",
                 "report_stdout": True,
             },
+            "python_job_no_output_suppress": {
+                "run_args_template": "python jobs.py hello_world_no_output",
+                "report_stdout": True,
+                "suppress_empty": True,
+            },
             "python_job_long_code_output": {
                 "run_args_template": "python jobs.py long_code_output",
                 "report_format": "code",

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -14,7 +14,12 @@ from bennettbot.config import get_support_config
 from bennettbot.dispatcher import JobDispatcher, MessageChecker, run_once
 from bennettbot.slack import slack_web_client
 
-from .assertions import assert_call_counts, assert_slack_client_sends_messages
+from .assertions import (
+    assert_call_counts,
+    assert_slack_client_doesnt_react_to_message,
+    assert_slack_client_reacts_to_message,
+    assert_slack_client_sends_messages,
+)
 from .job_configs import config
 from .mock_http_request import (
     get_mock_received_requests,
@@ -461,7 +466,8 @@ def test_python_job_with_no_output():
 
 
 def test_python_job_with_no_output_suppressed():
-    # With suppress_empty=True, empty stdout means no Slack message is posted.
+    # With suppress_empty=True and no message_ts, empty stdout means no
+    # Slack message is posted and no reaction is added.
     log_dir = build_log_dir("test_python_job_no_output_suppress")
 
     scheduler.schedule_job("test_python_job_no_output_suppress", {}, "channel", TS, 0)
@@ -473,9 +479,76 @@ def test_python_job_with_no_output_suppressed():
             {"channel": "logs", "text": "about to start"},
         ],
     )
+    assert_slack_client_doesnt_react_to_message()
 
     with open(os.path.join(log_dir, "stdout")) as f:
         assert f.read() == ""
+
+
+def test_python_job_with_no_output_suppressed_reacts_to_message():
+    # With suppress_empty=True and a message_ts, the dispatcher reacts to the
+    # requesting Slack message instead of posting a "no output" message.
+    build_log_dir("test_python_job_no_output_suppress")
+
+    scheduler.schedule_job(
+        "test_python_job_no_output_suppress",
+        {},
+        "channel",
+        TS,
+        0,
+        message_ts="1234567890.123456",
+    )
+    job = scheduler.reserve_job()
+
+    do_job(slack_web_client(), job)
+    assert_slack_client_sends_messages(
+        messages_kwargs=[
+            {"channel": "logs", "text": "about to start"},
+        ],
+    )
+    assert_slack_client_reacts_to_message(1)
+    request = get_mock_received_requests()["/api/reactions.add"][0]
+    assert request["channel"] == ["channel"]
+    assert request["timestamp"] == ["1234567890.123456"]
+    assert request["name"] == ["white_check_mark"]
+
+
+def test_successful_job_reacts_with_check_mark():
+    # A successful slack-triggered job adds :white_check_mark: to the
+    # requesting message.
+    build_log_dir("test_good_job")
+
+    scheduler.schedule_job(
+        "test_good_job", {}, "channel", TS, 0, message_ts="1234567890.123456"
+    )
+    job = scheduler.reserve_job()
+
+    do_job(slack_web_client(), job)
+    assert_slack_client_reacts_to_message(1)
+    request = get_mock_received_requests()["/api/reactions.add"][0]
+    assert request["name"] == ["white_check_mark"]
+    assert request["timestamp"] == ["1234567890.123456"]
+
+
+def test_failed_job_reacts_with_x():
+    # A failed slack-triggered job adds :x: to the requesting message.
+    build_log_dir("test_bad_python_job")
+
+    scheduler.schedule_job(
+        "test_bad_python_job",
+        {},
+        "channel",
+        TS,
+        0,
+        message_ts="1234567890.123456",
+    )
+    job = scheduler.reserve_job()
+
+    do_job(slack_web_client(), job)
+    assert_slack_client_reacts_to_message(1)
+    request = get_mock_received_requests()["/api/reactions.add"][0]
+    assert request["name"] == ["x"]
+    assert request["timestamp"] == ["1234567890.123456"]
 
 
 def test_job_success_config_with_no_python_file():

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -460,6 +460,24 @@ def test_python_job_with_no_output():
         assert f.read() == ""
 
 
+def test_python_job_with_no_output_suppressed():
+    # With suppress_empty=True, empty stdout means no Slack message is posted.
+    log_dir = build_log_dir("test_python_job_no_output_suppress")
+
+    scheduler.schedule_job("test_python_job_no_output_suppress", {}, "channel", TS, 0)
+    job = scheduler.reserve_job()
+
+    do_job(slack_web_client(), job)
+    assert_slack_client_sends_messages(
+        messages_kwargs=[
+            {"channel": "logs", "text": "about to start"},
+        ],
+    )
+
+    with open(os.path.join(log_dir, "stdout")) as f:
+        assert f.read() == ""
+
+
 def test_job_success_config_with_no_python_file():
     log_dir = build_log_dir("test1_good_job")
 

--- a/tests/test_github_rest_api.py
+++ b/tests/test_github_rest_api.py
@@ -75,10 +75,12 @@ def test_client_sends_expected_headers():
 def test_get_paginated_json_with_results_key_unwraps_pages():
     client = github_rest_api.GitHubAPIClient("test-token")
     page1 = MagicMock(
+        status_code=200,
         links={"next": {"url": "https://api.github.com/page2"}},
+        headers={},
     )
     page1.json.return_value = {"codespaces": [{"name": "a"}, {"name": "b"}]}
-    page2 = MagicMock(links={})
+    page2 = MagicMock(status_code=200, links={}, headers={})
     page2.json.return_value = {"codespaces": [{"name": "c"}]}
     with patch.object(
         github_rest_api.readonly_session, "get", side_effect=[page1, page2]
@@ -93,9 +95,13 @@ def test_get_paginated_json_with_results_key_unwraps_pages():
 
 def test_get_paginated_json_follows_link_header_and_passes_params_once():
     client = github_rest_api.GitHubAPIClient("test-token")
-    page1 = MagicMock(links={"next": {"url": "https://api.github.com/page2"}})
+    page1 = MagicMock(
+        status_code=200,
+        links={"next": {"url": "https://api.github.com/page2"}},
+        headers={},
+    )
     page1.json.return_value = [1, 2, 3]
-    page2 = MagicMock(links={})
+    page2 = MagicMock(status_code=200, links={}, headers={})
     page2.json.return_value = [4, 5]
     with patch.object(
         github_rest_api.readonly_session, "get", side_effect=[page1, page2]
@@ -109,4 +115,30 @@ def test_get_paginated_json_follows_link_header_and_passes_params_once():
     # The Link-header URL already encodes the original query string, so subsequent
     # pages must not re-send the caller's params.
     assert mock_get.call_args_list[0].kwargs["params"] == {"foo": "bar"}
-    assert mock_get.call_args_list[1].kwargs["params"] is None
+    # The second call is a positional-only invocation of `_session.get(next_url,
+    # headers=…)` so it has no `params` kwarg.
+    assert "params" not in mock_get.call_args_list[1].kwargs
+
+
+def test_get_paginated_json_exposes_first_page_etag():
+    client = github_rest_api.GitHubAPIClient("test-token")
+    response = MagicMock(status_code=200, links={}, headers={"ETag": "p1-etag"})
+    response.json.return_value = [1, 2]
+    with patch.object(github_rest_api.readonly_session, "get", return_value=response):
+        result = client.get_paginated_json("https://api.github.com/x")
+    assert result.etag == "p1-etag"
+    assert not result.not_modified
+    assert list(result) == [1, 2]
+
+
+def test_get_paginated_json_with_etag_returns_not_modified_on_304():
+    client = github_rest_api.GitHubAPIClient("test-token")
+    response = MagicMock(status_code=304)
+    with patch.object(
+        github_rest_api.readonly_session, "get", return_value=response
+    ) as mock_get:
+        result = client.get_paginated_json("https://api.github.com/x", etag="old-etag")
+    assert result.not_modified
+    assert result.etag == "old-etag"
+    assert list(result) == []
+    assert mock_get.call_args.kwargs["headers"]["If-None-Match"] == "old-etag"

--- a/tests/test_github_rest_api.py
+++ b/tests/test_github_rest_api.py
@@ -1,0 +1,112 @@
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from workspace.utils import github_rest_api
+
+
+WORKSPACE = Path("workspace")
+
+# Files in workspace/ allowed to make POST requests
+# We expect that jobs will only make GET requests (enforced by github_rest_api.py
+# for GitHub REST requests).
+# Some jobs may legitimately need to; currently that's only the reports which
+# use the GraphQL API to make reads that go via POST.
+# We could do complicated things to report only on request to github.com, but
+# since nothing else needs to POST (or do any other non-GET method) atm, we just mark
+# the specific files that can be excluded from the check. In future we might want to
+# make this exclusion more targeted, but this is sufficient for now.
+ALL_METHODS_ALLOWED = {
+    Path("workspace/report/generate_report.py"),
+}
+
+WRITE_METHOD_PATTERN = re.compile(r"\brequests\.(post|put|patch|delete)\b")
+
+
+def test_no_write_http_calls_in_workspace():
+    """Workspace jobs that call the GitHub API should be read-only; any write would
+    have to bypass workspace/utils/github_rest_api.py, which enforces GET calls only.
+    Fail if workspace file invokes a non-GET requests method, except those explicitly
+    allowlisted for read-only POSTs (e.g. GraphQL queries). Note that this will fail
+    on non-GET request to ANY url, not just github, but that's ok for now.
+    """
+    offenders = []
+    for path in WORKSPACE.rglob("*.py"):
+        if path in ALL_METHODS_ALLOWED:
+            # allow any method for this path
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if WRITE_METHOD_PATTERN.search(line):  # pragma: no cover
+                # Only reachable when something is broken; we'd assert below.
+                offenders.append(f"{path}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Found non-GET requests calls in workspace/. If this is a GitHub REST API"
+        "call, it should be read-only and go through workspace/utils/github_rest_api.py.\n"
+        "If this file should legitimately be using non-GET calls, add it to POST_ALLOWED."
+        + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("method", ["post", "put", "patch", "delete", "head"])
+def test_read_only_session_rejects_non_get(method):
+    session = github_rest_api.ReadOnlySession()
+    with pytest.raises(RuntimeError, match="read-only"):
+        getattr(session, method)("https://api.github.com/anything")
+
+
+def test_client_sends_expected_headers():
+    client = github_rest_api.GitHubAPIClient("test-token", api_version="2024-01-01")
+    response = MagicMock(links={})
+    response.json.return_value = {"ok": True}
+    with patch.object(
+        github_rest_api.readonly_session, "get", return_value=response
+    ) as mock_get:
+        client.get_json("https://api.github.com/example")
+    assert mock_get.call_args.kwargs["headers"] == {
+        "Authorization": "Bearer test-token",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "bennettbot",
+        "X-GitHub-Api-Version": "2024-01-01",
+    }
+
+
+def test_get_paginated_json_with_results_key_unwraps_pages():
+    client = github_rest_api.GitHubAPIClient("test-token")
+    page1 = MagicMock(
+        links={"next": {"url": "https://api.github.com/page2"}},
+    )
+    page1.json.return_value = {"codespaces": [{"name": "a"}, {"name": "b"}]}
+    page2 = MagicMock(links={})
+    page2.json.return_value = {"codespaces": [{"name": "c"}]}
+    with patch.object(
+        github_rest_api.readonly_session, "get", side_effect=[page1, page2]
+    ):
+        results = list(
+            client.get_paginated_json(
+                "https://api.github.com/page1", results_key="codespaces"
+            )
+        )
+    assert results == [{"name": "a"}, {"name": "b"}, {"name": "c"}]
+
+
+def test_get_paginated_json_follows_link_header_and_passes_params_once():
+    client = github_rest_api.GitHubAPIClient("test-token")
+    page1 = MagicMock(links={"next": {"url": "https://api.github.com/page2"}})
+    page1.json.return_value = [1, 2, 3]
+    page2 = MagicMock(links={})
+    page2.json.return_value = [4, 5]
+    with patch.object(
+        github_rest_api.readonly_session, "get", side_effect=[page1, page2]
+    ) as mock_get:
+        results = list(
+            client.get_paginated_json(
+                "https://api.github.com/page1", params={"foo": "bar"}
+            )
+        )
+    assert results == [1, 2, 3, 4, 5]
+    # The Link-header URL already encodes the original query string, so subsequent
+    # pages must not re-send the caller's params.
+    assert mock_get.call_args_list[0].kwargs["params"] == {"foo": "bar"}
+    assert mock_get.call_args_list[1].kwargs["params"] is None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,10 @@
+import sqlite3
+from contextlib import closing
+
 import pytest
 
-from bennettbot import scheduler
+from bennettbot import scheduler, settings
+from bennettbot.connection import get_connection
 
 from .assertions import (
     assert_job_matches,
@@ -272,3 +276,32 @@ def test_mark_job_done(freezer):
     scheduler.mark_job_done(job_id)
 
     assert not scheduler.get_jobs()
+
+
+def test_get_connection_adds_message_ts_to_legacy_table():
+    """Pre-message_ts job tables should be migrated on connection."""
+    with closing(sqlite3.connect(settings.DB_PATH)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE job (
+                id INTEGER PRIMARY KEY,
+                type TEXT NOT NULL,
+                args TEXT,
+                channel TEXT,
+                thread_ts TEXT,
+                start_after DATETIME,
+                started_at DATETIME,
+                is_im BOOLEAN
+            )
+            """
+        )
+        conn.commit()
+    with closing(get_connection()) as conn:
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(job)")}
+    assert "message_ts" in columns
+
+
+def test_schedule_job_with_message_ts():
+    scheduler.schedule_job("good_job", {"k": "v"}, "channel", TS, 0, message_ts="42.42")
+    jobs = scheduler.get_jobs_of_type("good_job")
+    assert jobs[0]["message_ts"] == "42.42"

--- a/tests/workspace/dependabot_alerts.json
+++ b/tests/workspace/dependabot_alerts.json
@@ -1,0 +1,37 @@
+[
+    {
+        "number": 1,
+        "state": "open",
+        "dependency": {"package": {"name": "package-a", "ecosystem": "pip"}, "manifest_path": "requirements.txt"},
+        "security_advisory": {"severity": "critical", "summary": "Critical issue in package-a"},
+        "html_url": "https://github.com/opensafely-core/airlock/security/dependabot/1"
+    },
+    {
+        "number": 2,
+        "state": "open",
+        "dependency": {"package": {"name": "package-b", "ecosystem": "pip"}, "manifest_path": "requirements.txt"},
+        "security_advisory": {"severity": "critical", "summary": "Critical issue in package-b"},
+        "html_url": "https://github.com/opensafely-core/airlock/security/dependabot/2"
+    },
+    {
+        "number": 3,
+        "state": "open",
+        "dependency": {"package": {"name": "package-c", "ecosystem": "npm"}, "manifest_path": "package.json"},
+        "security_advisory": {"severity": "high", "summary": "High issue in package-c"},
+        "html_url": "https://github.com/opensafely-core/airlock/security/dependabot/3"
+    },
+    {
+        "number": 4,
+        "state": "open",
+        "dependency": {"package": {"name": "package-d", "ecosystem": "npm"}, "manifest_path": "package.json"},
+        "security_advisory": {"severity": "high", "summary": "High issue in package-d"},
+        "html_url": "https://github.com/opensafely-core/airlock/security/dependabot/4"
+    },
+    {
+        "number": 5,
+        "state": "open",
+        "dependency": {"package": {"name": "package-e", "ecosystem": "npm"}, "manifest_path": "package.json"},
+        "security_advisory": {"severity": "high", "summary": "High issue in package-e"},
+        "html_url": "https://github.com/opensafely-core/airlock/security/dependabot/5"
+    }
+]

--- a/tests/workspace/test_security.py
+++ b/tests/workspace/test_security.py
@@ -8,10 +8,17 @@ from mocket import Mocketizer, mocketize
 from mocket.mockhttp import Entry
 
 from workspace.security import jobs
+from workspace.utils.github_rest_api import PagedResponse
 
 
 ALERTS_FIXTURE_PATH = Path("tests/workspace/dependabot_alerts.json")
 ALERTS_URL = "https://api.github.com/repos/opensafely-core/airlock/dependabot/alerts"
+
+
+@pytest.fixture(autouse=True)
+def isolated_cache(tmp_path, monkeypatch):
+    """Each test gets its own cache file so cache state doesn't bleed between tests."""
+    monkeypatch.setattr(jobs, "CACHE_PATH", tmp_path / "security_cache.json")
 
 
 @pytest.fixture
@@ -93,6 +100,72 @@ def test_get_counts_no_alerts():
     )
     reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
     assert reporter.get_counts() == {"critical": 0, "high": 0}
+
+
+def test_cache_hit_uses_cached_alerts():
+    # Pre-populate the cache; the github client returns a not_modified
+    # response to simulate a 304 from the server.
+    cached_alerts = [{"security_advisory": {"severity": "critical"}}]
+    jobs.save_cache(
+        {
+            "opensafely-core/airlock|critical,high": {
+                "etag": "old-etag",
+                "alerts": cached_alerts,
+            }
+        }
+    )
+    with patch.object(
+        jobs.github_client,
+        "get_paginated_json",
+        return_value=PagedResponse(
+            records=iter([]), etag="old-etag", not_modified=True
+        ),
+    ) as mock_get:
+        reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    # The cached etag was passed through and the cached alerts re-used.
+    assert mock_get.call_args.kwargs["etag"] == "old-etag"
+    assert reporter.alerts == cached_alerts
+
+
+def test_cache_miss_stores_response_and_etag():
+    fresh_alerts = [{"security_advisory": {"severity": "high"}}]
+    with patch.object(
+        jobs.github_client,
+        "get_paginated_json",
+        return_value=PagedResponse(records=iter(fresh_alerts), etag="new-etag"),
+    ):
+        reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    assert reporter.alerts == fresh_alerts
+    assert jobs.load_cache() == {
+        "opensafely-core/airlock|critical,high": {
+            "etag": "new-etag",
+            "alerts": fresh_alerts,
+        }
+    }
+
+
+def test_cache_key_distinguishes_severities():
+    # A cache entry for critical/high must not be served for an
+    # all-severities request: the API filter is different so the cached
+    # alerts list would be missing entries.
+    jobs.save_cache(
+        {
+            "opensafely-core/airlock|critical,high": {
+                "etag": "default-etag",
+                "alerts": [{"security_advisory": {"severity": "critical"}}],
+            }
+        }
+    )
+    with patch.object(
+        jobs.github_client,
+        "get_paginated_json",
+        return_value=PagedResponse(records=iter([]), etag="all-sev-etag"),
+    ) as mock_get:
+        jobs.RepoAlertsReporter(
+            "opensafely-core/airlock", severities=jobs.ALL_SEVERITIES
+        )
+    # No cached etag was passed (different cache key for the all-severities request).
+    assert mock_get.call_args.kwargs["etag"] is None
 
 
 def test_report_with_alerts(mock_alerts_endpoint):

--- a/tests/workspace/test_security.py
+++ b/tests/workspace/test_security.py
@@ -1,0 +1,652 @@
+import functools
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from mocket import Mocketizer, mocketize
+from mocket.mockhttp import Entry
+
+from workspace.security import jobs
+
+
+ALERTS_FIXTURE_PATH = Path("tests/workspace/dependabot_alerts.json")
+ALERTS_URL = "https://api.github.com/repos/opensafely-core/airlock/dependabot/alerts"
+
+
+@pytest.fixture
+def mock_alerts_endpoint():
+    Entry.single_register(
+        Entry.GET,
+        ALERTS_URL,
+        body=ALERTS_FIXTURE_PATH.read_text(),
+        match_querystring=False,
+    )
+    with Mocketizer(strict_mode=True):
+        yield
+
+
+class MockRepoAlertsReporter(jobs.RepoAlertsReporter):
+    """Skip the HTTP call in __init__ and let tests inject alerts via class attr."""
+
+    counts_by_repo_full_name: dict = {}
+
+    def __init__(self, repo_full_name, severities=None):
+        self.repo_full_name = repo_full_name
+        self.severities = severities or jobs.DEFAULT_SEVERITIES
+        self.base_api_url = f"https://api.github.com/repos/{repo_full_name}/"
+        self.dependabot_link = jobs.get_dependabot_alerts_link(repo_full_name)
+        self.alerts = []
+
+    def get_counts(self):
+        zeros = {sev: 0 for sev in self.severities}
+        return dict(self.counts_by_repo_full_name.get(self.repo_full_name, zeros))
+
+
+def use_mock_results(repos_config, counts_by_repo_full_name):
+    """Patch config.REPOS and RepoAlertsReporter so summary tests don't make HTTP calls."""
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            MockRepoAlertsReporter.counts_by_repo_full_name = counts_by_repo_full_name
+            with (
+                patch("workspace.utils.repos_config.REPOS", repos_config),
+                patch(
+                    "workspace.security.jobs.RepoAlertsReporter", MockRepoAlertsReporter
+                ),
+            ):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def test_get_open_alerts_and_counts(mock_alerts_endpoint):
+    reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    assert len(reporter.alerts) == 5
+    assert reporter.get_counts() == {"critical": 2, "high": 3}
+
+
+def test_get_counts_skips_unknown_severity():
+    with patch.object(
+        jobs.RepoAlertsReporter,
+        "get_open_alerts",
+        return_value=[
+            {"security_advisory": {"severity": "critical"}},
+            {"security_advisory": {"severity": "medium"}},
+            {"security_advisory": {}},
+        ],
+    ):
+        reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    assert reporter.get_counts() == {"critical": 1, "high": 0}
+
+
+@mocketize(strict_mode=True)
+def test_get_counts_no_alerts():
+    Entry.single_register(
+        Entry.GET,
+        ALERTS_URL,
+        body="[]",
+        match_querystring=False,
+    )
+    reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    assert reporter.get_counts() == {"critical": 0, "high": 0}
+
+
+def test_report_with_alerts(mock_alerts_endpoint):
+    reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    blocks = reporter.report_blocks()
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":rotating_light: Open Critical/High Security Alerts :rotating_light: for opensafely-core/airlock",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": ":red_circle: 2 critical, :large_orange_circle: 3 high",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://github.com/opensafely-core/airlock/security/dependabot|View security alerts>",
+            },
+        },
+    ]
+
+
+@mocketize(strict_mode=True)
+def test_report_no_alerts():
+    Entry.single_register(
+        Entry.GET,
+        ALERTS_URL,
+        body="[]",
+        match_querystring=False,
+    )
+    reporter = jobs.RepoAlertsReporter("opensafely-core/airlock")
+    blocks = reporter.report_blocks()
+    assert (
+        blocks[1]["text"]["text"]
+        == ":red_circle: 0 critical, :large_orange_circle: 0 high"
+    )
+
+
+REPOS_CONFIG = {
+    "airlock": {"org": "opensafely-core", "team": "Team RAP"},
+    "ehrql": {"org": "opensafely-core", "team": "Team RAP"},
+    "job-server": {"org": "opensafely-core", "team": "Team REX"},
+    "documentation": {"org": "opensafely", "team": "Tech shared"},
+}
+
+
+def test_get_repo_full_names_for_team():
+    from workspace.utils import repos_config
+
+    with patch("workspace.utils.repos_config.REPOS", REPOS_CONFIG):
+        assert repos_config.get_repo_full_names_for_team("Team RAP") == [
+            "opensafely-core/airlock",
+            "opensafely-core/ehrql",
+        ]
+        assert repos_config.get_repo_full_names_for_team("Team Prescribosaurus") == []
+
+
+def test_get_repo_full_names_for_org():
+    from workspace.utils import repos_config
+
+    with patch("workspace.utils.repos_config.REPOS", REPOS_CONFIG):
+        assert sorted(repos_config.get_repo_full_names_for_org("opensafely-core")) == [
+            "opensafely-core/airlock",
+            "opensafely-core/ehrql",
+            "opensafely-core/job-server",
+        ]
+        assert repos_config.get_repo_full_names_for_org("opensafely") == [
+            "opensafely/documentation"
+        ]
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 2, "high": 3},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+        "opensafely-core/job-server": {"critical": 0, "high": 1},
+        "opensafely/documentation": {"critical": 0, "high": 0},
+    },
+)
+def test_summarise_team_skips_zero_alert_repos():
+    blocks = jobs.summarise_team("Team RAP", jobs.DEFAULT_SEVERITIES)
+    assert blocks == [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*Team RAP*"},
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://github.com/opensafely-core/airlock/security/dependabot|opensafely-core/airlock>: :red_circle: 2 critical, :large_orange_circle: 3 high",
+            },
+        },
+    ]
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 0, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+    },
+)
+def test_summarise_team_all_zero_returns_empty():
+    assert jobs.summarise_team("Team RAP", jobs.DEFAULT_SEVERITIES) == []
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 1, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+        "opensafely-core/job-server": {"critical": 0, "high": 2},
+        "opensafely/documentation": {"critical": 0, "high": 0},
+    },
+)
+def test_summarise_all_groups_by_team():
+    blocks = jobs.summarise_all(jobs.DEFAULT_SEVERITIES)
+    # One top-level header, then bold subheaders per team
+    headers = [b["text"]["text"] for b in blocks if b["type"] == "header"]
+    subheaders = [
+        b["text"]["text"]
+        for b in blocks
+        if b["type"] == "section" and b["text"]["text"].startswith("*")
+    ]
+    assert headers == [
+        ":rotating_light: Open Critical/High Security Alerts :rotating_light:"
+    ]
+    # Subheaders appear in config.TEAMS order ("Team REX" before "Team RAP")
+    assert subheaders == ["*Team REX*", "*Team RAP*"]
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 0, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+        "opensafely-core/job-server": {"critical": 0, "high": 0},
+        "opensafely/documentation": {"critical": 0, "high": 0},
+    },
+)
+def test_summarise_all_nothing_to_report():
+    blocks = jobs.summarise_all(jobs.DEFAULT_SEVERITIES)
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":white_check_mark: No open critical or high severity alerts to report!",
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize("command", ["report", "report --target all"])
+def test_all_as_target(command):
+    args = jobs.get_command_line_parser().parse_args(command.split())
+    with patch("workspace.security.jobs.summarise_all") as mock_summarise_all:
+        mock_summarise_all.return_value = []
+        jobs.main(args)
+        mock_summarise_all.assert_called_once_with(jobs.DEFAULT_SEVERITIES, quiet=False)
+
+
+@pytest.mark.parametrize(
+    "target,resolved",
+    [
+        ("rap", "Team RAP"),
+        ("rex", "Team REX"),
+        ("presc", "Team Prescribosaurus"),
+    ],
+)
+def test_team_as_target(target, resolved):
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", target])
+    with patch("workspace.security.jobs.summarise_team") as mock_summarise_team:
+        mock_summarise_team.return_value = []
+        jobs.main(args)
+        mock_summarise_team.assert_called_once_with(resolved, jobs.DEFAULT_SEVERITIES)
+
+
+@pytest.mark.parametrize("org", ["opensafely-core", "osc"])
+def test_org_as_target(org):
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", org])
+    with patch("workspace.security.jobs.summarise_org") as mock_summarise_org:
+        mock_summarise_org.return_value = []
+        jobs.main(args)
+        mock_summarise_org.assert_called_once_with(
+            "opensafely-core", jobs.DEFAULT_SEVERITIES
+        )
+
+
+@pytest.mark.parametrize(
+    "target, parsed",
+    [
+        ("opensafely-core/airlock", "opensafely-core/airlock"),
+        ("osc/airlock", "opensafely-core/airlock"),
+        ("airlock", "opensafely-core/airlock"),
+        ("opensafely/unknown-repo", "opensafely/unknown-repo"),
+        ("os/unknown-repo", "opensafely/unknown-repo"),
+    ],
+)
+def test_repo_as_target(target, parsed):
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", target])
+    with patch("workspace.security.jobs.RepoAlertsReporter") as MockReporter:
+        MockReporter.return_value.report_blocks.return_value = []
+        MockReporter.return_value.get_counts.return_value = {"critical": 0, "high": 0}
+        jobs.main(args)
+        MockReporter.assert_called_once_with(parsed, severities=jobs.DEFAULT_SEVERITIES)
+
+
+def test_list_of_teams_as_target():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "rap rex"])
+    with patch("workspace.security.jobs.summarise_team") as mock_summarise_team:
+        mock_summarise_team.return_value = []
+        jobs.main(args)
+        mock_summarise_team.assert_any_call("Team RAP", jobs.DEFAULT_SEVERITIES)
+        mock_summarise_team.assert_called_with("Team REX", jobs.DEFAULT_SEVERITIES)
+        assert mock_summarise_team.call_count == 2
+
+
+def test_list_of_orgs_as_target():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "osc ebm"])
+    with patch("workspace.security.jobs.summarise_org") as mock_summarise_org:
+        mock_summarise_org.return_value = []
+        jobs.main(args)
+        mock_summarise_org.assert_any_call("opensafely-core", jobs.DEFAULT_SEVERITIES)
+        mock_summarise_org.assert_called_with("ebmdatalab", jobs.DEFAULT_SEVERITIES)
+        assert mock_summarise_org.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["some/invalid/input", "totally-unknown"],
+)
+def test_invalid_target(target):
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", target])
+    blocks = json.loads(jobs.main(args))
+    assert blocks[0] == {
+        "type": "header",
+        "text": {"type": "plain_text", "text": f"{target} was not recognised"},
+    }
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["rap osc", "rap airlock", "osc airlock"],
+)
+def test_mixed_list_as_target(target):
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", target])
+    blocks = json.loads(jobs.main(args))
+    assert blocks[0] == {
+        "type": "header",
+        "text": {"type": "plain_text", "text": "Invalid list of targets"},
+    }
+
+
+def test_catch_unhandled_error():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "all"])
+    with patch(
+        "workspace.security.jobs.summarise_all",
+        side_effect=Exception("boom"),
+    ):
+        blocks = json.loads(jobs.main(args))
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "An error occurred reporting security alerts for all",
+            },
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "boom"},
+        },
+    ]
+
+
+def test_print_usage():
+    text = jobs.get_usage_text(None)
+    assert text.startswith("Usage for `security report [target]`:")
+    assert "Team RAP" in text
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 2, "high": 3},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+    },
+)
+def test_main_show_team_wraps_top_header():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "rap"])
+    blocks = json.loads(jobs.main(args))
+    assert blocks[0] == {
+        "type": "header",
+        "text": {
+            "type": "plain_text",
+            "text": ":rotating_light: Open Critical/High Security Alerts :rotating_light:",
+        },
+    }
+    assert blocks[1] == {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*Team RAP*"},
+    }
+    assert blocks[2]["text"]["text"].startswith(
+        "<https://github.com/opensafely-core/airlock/security/dependabot|opensafely-core/airlock>:"
+    )
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 1, "high": 0},
+        "opensafely-core/job-server": {"critical": 0, "high": 2},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+    },
+)
+def test_main_show_org_wraps_top_header():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "osc"])
+    blocks = json.loads(jobs.main(args))
+    assert (
+        blocks[0]["text"]["text"]
+        == ":rotating_light: Open Critical/High Security Alerts :rotating_light:"
+    )
+    assert blocks[1]["text"]["text"] == "*opensafely-core*"
+    body_texts = [b["text"]["text"] for b in blocks[2:]]
+    assert any("opensafely-core/airlock" in t for t in body_texts)
+    assert any("opensafely-core/job-server" in t for t in body_texts)
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 1, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 2},
+    },
+)
+def test_main_show_repo_list_has_top_header_no_subheader():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "airlock ehrql"]
+    )
+    blocks = json.loads(jobs.main(args))
+    assert (
+        blocks[0]["text"]["text"]
+        == ":rotating_light: Open Critical/High Security Alerts :rotating_light:"
+    )
+    # No subheader between top header and repo lines
+    assert not blocks[1]["text"]["text"].startswith("*")
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 0, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+    },
+)
+def test_main_show_team_no_alerts():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "rap"])
+    blocks = json.loads(jobs.main(args))
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":white_check_mark: No open critical or high severity alerts to report!",
+            },
+        }
+    ]
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 0, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+        "opensafely-core/job-server": {"critical": 0, "high": 0},
+        "opensafely/documentation": {"critical": 0, "high": 0},
+    },
+)
+def test_main_quiet_no_alerts_returns_empty_string():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "all", "--quiet"]
+    )
+    assert jobs.main(args) == ""
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {"critical": 1, "high": 0},
+        "opensafely-core/ehrql": {"critical": 0, "high": 0},
+        "opensafely-core/job-server": {"critical": 0, "high": 0},
+        "opensafely/documentation": {"critical": 0, "high": 0},
+    },
+)
+def test_main_quiet_with_alerts_still_reports():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "all", "--quiet"]
+    )
+    blocks = json.loads(jobs.main(args))
+    assert blocks[0]["text"]["text"] == (
+        ":rotating_light: Open Critical/High Security Alerts :rotating_light:"
+    )
+
+
+def test_main_quiet_single_repo_no_alerts_returns_empty_string():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "airlock", "--quiet"]
+    )
+    with patch("workspace.security.jobs.RepoAlertsReporter") as MockReporter:
+        MockReporter.return_value.get_counts.return_value = {"critical": 0, "high": 0}
+        assert jobs.main(args) == ""
+
+
+def test_main_quiet_single_repo_with_alerts_still_reports():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "airlock", "--quiet"]
+    )
+    with patch("workspace.security.jobs.RepoAlertsReporter") as MockReporter:
+        MockReporter.return_value.get_counts.return_value = {"critical": 1, "high": 0}
+        MockReporter.return_value.report_blocks.return_value = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "alerts!"}}
+        ]
+        assert jobs.main(args) != ""
+
+
+def test_invalid_target_message_references_usage():
+    args = jobs.get_command_line_parser().parse_args(["report", "--target", "nope"])
+    blocks = json.loads(jobs.main(args))
+    assert (
+        "Run `@test_username security usage` to see the valid values"
+        in blocks[1]["text"]["text"]
+    )
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {
+            "critical": 1,
+            "high": 0,
+            "medium": 2,
+            "low": 0,
+        },
+        "opensafely-core/ehrql": {
+            "critical": 0,
+            "high": 0,
+            "medium": 0,
+            "low": 1,
+        },
+    },
+)
+def test_main_all_severities_uses_all_severity_header():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "rap", "--all-severities"]
+    )
+    blocks = json.loads(jobs.main(args))
+    assert blocks[0]["text"]["text"] == (
+        ":rotating_light: Open Security Alerts :rotating_light:"
+    )
+    # Each summary line should list all severities with non-zero counts
+    body_texts = [b["text"]["text"] for b in blocks[1:]]
+    assert any("medium" in t for t in body_texts)
+    assert any("low" in t for t in body_texts)
+
+
+@use_mock_results(
+    REPOS_CONFIG,
+    {
+        "opensafely-core/airlock": {
+            "critical": 0,
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+        },
+        "opensafely-core/ehrql": {
+            "critical": 0,
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+        },
+    },
+)
+def test_main_all_severities_nothing_to_report_message():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "rap", "--all-severities"]
+    )
+    blocks = json.loads(jobs.main(args))
+    assert blocks == [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":white_check_mark: No open security alerts to report!",
+            },
+        }
+    ]
+
+
+def test_main_all_severities_single_repo_header_label():
+    args = jobs.get_command_line_parser().parse_args(
+        ["report", "--target", "airlock", "--all-severities"]
+    )
+    with patch("workspace.security.jobs.RepoAlertsReporter") as MockReporter:
+        MockReporter.return_value.severities = jobs.ALL_SEVERITIES
+        MockReporter.return_value.get_counts.return_value = dict.fromkeys(
+            jobs.ALL_SEVERITIES, 0
+        )
+        MockReporter.return_value.report_blocks.return_value = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": (
+                        "Open all-severity security alerts for opensafely-core/airlock"
+                    ),
+                },
+            }
+        ]
+        result = jobs.main(args)
+    MockReporter.assert_called_once_with(
+        "opensafely-core/airlock", severities=jobs.ALL_SEVERITIES
+    )
+    blocks = json.loads(result)
+    assert (
+        blocks[0]["text"]["text"]
+        == "Open all-severity security alerts for opensafely-core/airlock"
+    )
+
+
+@pytest.mark.parametrize(
+    "text, expected_job_type",
+    [
+        ("security report", "security_report_all_targets"),
+        ("security report airlock", "security_report"),
+        ("security check", "security_check_all_targets"),
+        ("security check airlock", "security_check"),
+        ("security report-all", "security_report_all_severities_all_targets"),
+        ("security report-all airlock", "security_report_all_severities"),
+    ],
+)
+def test_security_slack_routing(text, expected_job_type):
+    """Sanity-check that each verb routes to the expected job."""
+    from bennettbot.job_configs import config as bot_config
+
+    matched = next(sc for sc in bot_config["slack"] if sc["regex"].match(text))
+    assert matched["job_type"] == expected_job_type

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -135,7 +135,7 @@ def use_mock_results(patch_settings):
             }
             # Patch the config and use results from the mock cache
             with (
-                patch("workspace.workflows.config.REPOS", mock_repos_config),
+                patch("workspace.utils.repos_config.REPOS", mock_repos_config),
                 patch("workspace.workflows.jobs.load_cache", return_value=mock_cache),
                 patch(
                     "workspace.workflows.jobs.RepoWorkflowReporter",
@@ -812,7 +812,7 @@ def test_main_show_all():
 
 
 @patch(
-    "workspace.workflows.config.WORKFLOWS_KNOWN_TO_FAIL",
+    "workspace.utils.repos_config.WORKFLOWS_KNOWN_TO_FAIL",
     {
         "opensafely/failing-repo": [82728346, 88048829, 94331150, 108457763, 113602598],
     },
@@ -908,7 +908,7 @@ def test_main_show_failed_found():
 
 
 @patch(
-    "workspace.workflows.config.WORKFLOWS_KNOWN_TO_FAIL",
+    "workspace.utils.repos_config.WORKFLOWS_KNOWN_TO_FAIL",
     {
         # Second-last workflow is known to fail
         "opensafely-core/airlock": [108457763],
@@ -998,7 +998,7 @@ def test_main_show_invalid_target():
 
 
 @patch(
-    "workspace.workflows.config.CUSTOM_WORKFLOWS_GROUPS",
+    "workspace.utils.repos_config.CUSTOM_WORKFLOWS_GROUPS",
     {
         "check-links": {
             "header_text": "Link-checking workflows",
@@ -1068,7 +1068,7 @@ def test_show_group():
 
 
 @patch(
-    "workspace.workflows.config.CUSTOM_WORKFLOWS_GROUPS",
+    "workspace.utils.repos_config.CUSTOM_WORKFLOWS_GROUPS",
     {"check-links": ...},
 )
 def test_show_group_not_found():

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -80,7 +80,7 @@ def mock_airlock_reporter():
     # Workflow IDs and names
     Entry.single_register(
         Entry.GET,
-        "https://api.github.com/repos/opensafely-core/airlock/actions/workflows?format=json",
+        "https://api.github.com/repos/opensafely-core/airlock/actions/workflows",
         body=Path("tests/workspace/workflows.json").read_text(),
         match_querystring=True,
     )
@@ -88,7 +88,7 @@ def mock_airlock_reporter():
     # Workflow runs
     Entry.single_register(
         Entry.GET,
-        "https://api.github.com/repos/opensafely-core/airlock/actions/runs?per_page=100&format=json",
+        "https://api.github.com/repos/opensafely-core/airlock/actions/runs?per_page=100",
         body=Path("tests/workspace/runs.json").read_text(),
         match_querystring=False,  # Test the querystring separately
     )
@@ -367,7 +367,7 @@ def test_get_workflows():
     # get_workflows is called in __init__, so create the instance here
     Entry.single_register(
         Entry.GET,
-        "https://api.github.com/repos/opensafely-core/airlock/actions/workflows?format=json",
+        "https://api.github.com/repos/opensafely-core/airlock/actions/workflows",
         match_querystring=True,
         body=Path("tests/workspace/workflows.json").read_text(),
     )
@@ -445,7 +445,6 @@ def test_get_runs_since_last_retrieval(mock_airlock_reporter, cache_path):
     assert Mocket.last_request().querystring == {
         "branch": ["main"],
         "per_page": ["100"],
-        "format": ["json"],
         "created": [f">={THIS_YEAR}-01-15T09:00:08Z"],
     }
 
@@ -620,7 +619,7 @@ def test_main_show_repo(mock_conclusions, conclusion, reported, emoji):
     # No need to mock CACHE_PATH since get_latest_conclusions is mocked
     Entry.single_register(
         Entry.GET,
-        "https://api.github.com/repos/opensafely-core/airlock/actions/workflows?format=json",
+        "https://api.github.com/repos/opensafely-core/airlock/actions/workflows",
         match_querystring=True,
         body=Path("tests/workspace/workflows.json").read_text(),
     )

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -15,7 +15,6 @@ import datetime
 import json
 import os
 
-import requests
 from slack_sdk.models.blocks import (
     HeaderBlock,
     RichTextBlock,
@@ -23,6 +22,8 @@ from slack_sdk.models.blocks import (
     RichTextListElement,
     RichTextSectionElement,
 )
+
+from workspace.utils.github_rest_api import GitHubAPIClient
 
 
 CODE = RichTextElementParts.TextStyle(code=True)
@@ -33,17 +34,15 @@ Emoji = RichTextElementParts.Emoji
 
 
 URL_PATTERN = "https://api.github.com/orgs/{org}/codespaces"
-# The following can be a classic PAT with the admin:org scope or a fine-grained token
-# with "Codespaces" repository permissions set to "read" and "Organization codespaces"
-# organization permissions set to "read". For more information, see:
+# The token can be a classic PAT with the admin:org scope or a fine-grained
+# token with "Codespaces" repository permissions set to "read" and
+# "Organization codespaces" organization permissions set to "read".
 # https://docs.github.com/en/rest/codespaces/organizations?apiVersion=2022-11-28#list-codespaces-for-the-organization
-# Someone with admin permissions on the organization needs to do this.
+# Someone with admin permissions on the organization needs to create it.
 # For the opensafely org, created PATs should be stored in BitWarden.
-TOKEN = os.environ["CODESPACES_GITHUB_API_TOKEN"]
-HEADERS = {
-    "Accept": "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-}
+github_client = GitHubAPIClient(
+    os.environ["CODESPACES_GITHUB_API_TOKEN"], api_version="2022-11-28"
+)
 
 
 Codespace = collections.namedtuple(
@@ -59,26 +58,6 @@ Codespace = collections.namedtuple(
         "has_unpushed",
     ],
 )
-
-
-def fetch(url, key):
-    """
-    Recursively fetch all records from the GitHub REST API endpoint given by `url`.
-    `key` is the property under which the records are stored.
-    """
-
-    def set_bearer_auth(request):
-        request.headers["Authorization"] = f"Bearer {TOKEN}"
-        return request
-
-    def fetch_one_page(page_url):
-        response = requests.get(page_url, auth=set_bearer_auth, headers=HEADERS)
-        response.raise_for_status()
-        yield from response.json().get(key)
-        if "next" in response.links:
-            yield from fetch_one_page(response.links["next"]["url"])
-
-    yield from fetch_one_page(url)
 
 
 def get_codespace(record):
@@ -143,7 +122,9 @@ def main(threshold_in_days):
     ]
 
     # Fetch info on org CodeSpaces at risk from GitHub API.
-    records = fetch(URL_PATTERN.format(org=org), "codespaces")
+    records = github_client.get_paginated_json(
+        URL_PATTERN.format(org=org), results_key="codespaces"
+    )
     codespaces = (get_codespace(rec) for rec in records)
     at_risk_codespaces = sorted(
         (

--- a/workspace/security/jobs.py
+++ b/workspace/security/jobs.py
@@ -1,0 +1,345 @@
+import argparse
+import json
+import os
+
+from bennettbot import settings
+from workspace.utils import repos_config as config
+from workspace.utils import shorthands
+from workspace.utils.argparse import SplitString
+from workspace.utils.blocks import (
+    get_basic_header_and_text_blocks,
+    get_header_block,
+    get_text_block,
+)
+from workspace.utils.github_rest_api import GitHubAPIClient
+
+
+# Requires `repo` scope (only needs `security_events` for public repos, but full
+# `repo` for private-repo access).
+github_client = GitHubAPIClient(os.environ["DATA_TEAM_GITHUB_API_TOKEN"])
+
+
+ALL_SEVERITIES = ["critical", "high", "medium", "low"]
+DEFAULT_SEVERITIES = ["critical", "high"]
+SEVERITY_EMOJI = {
+    "critical": ":red_circle:",
+    "high": ":large_orange_circle:",
+    "medium": ":large_yellow_circle:",
+    "low": ":large_blue_circle:",
+}
+
+
+def _top_header_text(severities: list[str]) -> str:
+    if set(severities) == set(ALL_SEVERITIES):
+        body = "Open Security Alerts"
+    else:
+        body = f"Open {'/'.join(s.title() for s in severities)} Security Alerts"
+    return f":rotating_light: {body} :rotating_light:"
+
+
+def _nothing_to_report_text(severities: list[str]) -> str:
+    if set(severities) == set(ALL_SEVERITIES):
+        body = "No open security alerts to report!"
+    else:
+        body = f"No open {' or '.join(severities)} severity alerts to report!"
+    return f":white_check_mark: {body}"
+
+
+def get_dependabot_alerts_link(repo_full_name: str) -> str:
+    return f"https://github.com/{repo_full_name}/security/dependabot"
+
+
+class RepoAlertsReporter:
+    def __init__(self, repo_full_name: str, severities: list[str] | None = None):
+        """
+        Fetches and reports on open Dependabot security alerts for a single repo.
+
+        Parameters:
+            repo_full_name: "org/repo" string (e.g. "opensafely-core/airlock").
+            severities: severities to fetch and report on. Defaults to critical/high.
+        """
+        self.repo_full_name = repo_full_name
+        self.severities = severities or DEFAULT_SEVERITIES
+        self.base_api_url = f"https://api.github.com/repos/{repo_full_name}/"
+        self.dependabot_link = get_dependabot_alerts_link(repo_full_name)
+        self.alerts = list(self.get_open_alerts())
+
+    def get_open_alerts(self):
+        url = f"{self.base_api_url}dependabot/alerts"
+        params = {
+            "state": "open",
+            "severity": ",".join(self.severities),
+            "per_page": 100,
+        }
+        return github_client.get_paginated_json(url, params=params)
+
+    def get_counts(self) -> dict:
+        counts = {sev: 0 for sev in self.severities}
+        for alert in self.alerts:
+            severity = alert.get("security_advisory", {}).get("severity")
+            # We request the severities from the api endpoint, but just in case the
+            # we get something unexpected in the response, make sure that each
+            # severity is one we expect
+            if severity in counts:
+                counts[severity] += 1
+        return counts
+
+    def report_blocks(self) -> list:
+        counts = self.get_counts()
+        text = ", ".join(
+            f"{SEVERITY_EMOJI[sev]} {counts[sev]} {sev}" for sev in self.severities
+        )
+        header = _top_header_text(self.severities) + f" for {self.repo_full_name}"
+        return [
+            get_header_block(header),
+            get_text_block(text),
+            get_text_block(f"<{self.dependabot_link}|View security alerts>"),
+        ]
+
+
+def get_summary_block(repo_full_name: str, counts: dict, severities: list[str]) -> dict:
+    link = get_dependabot_alerts_link(repo_full_name)
+    parts = [
+        f"{SEVERITY_EMOJI[sev]} {counts[sev]} {sev}"
+        for sev in severities
+        if counts[sev] > 0
+    ]
+    return get_text_block(f"<{link}|{repo_full_name}>: {', '.join(parts)}")
+
+
+def get_subheader_block(text: str) -> dict:
+    return get_text_block(f"*{text}*")
+
+
+def _repos_with_alerts(repo_full_names: list[str], severities: list[str]) -> list:
+    items = []
+    for repo_full_name in repo_full_names:
+        counts = RepoAlertsReporter(repo_full_name, severities=severities).get_counts()
+        if any(counts.values()):
+            items.append((repo_full_name, counts))
+    return items
+
+
+def _section_blocks(
+    subheader: str, repo_full_names: list[str], severities: list[str]
+) -> list:
+    """Subheader + repo summary lines for repos that have alerts. Empty if none."""
+    items = _repos_with_alerts(repo_full_names, severities)
+    if not items:
+        return []
+    return [
+        get_subheader_block(subheader),
+        *[
+            get_summary_block(repo_full_name, counts, severities)
+            for repo_full_name, counts in items
+        ],
+    ]
+
+
+def _wrap_with_top_header(
+    body: list, severities: list[str], quiet: bool = False
+) -> list:
+    if not body:
+        # Nothing to report - either return [], as a valid blocks output,
+        # which main() will turn into an empty string, or the nothing-to-report text
+        if quiet:
+            return []
+        return [get_header_block(_nothing_to_report_text(severities))]
+    return [get_header_block(_top_header_text(severities)), *body]
+
+
+def summarise_team(team: str, severities: list[str]) -> list:
+    return _section_blocks(team, config.get_repo_full_names_for_team(team), severities)
+
+
+def summarise_org(org: str, severities: list[str]) -> list:
+    return _section_blocks(org, config.get_repo_full_names_for_org(org), severities)
+
+
+def summarise_all(severities: list[str], quiet: bool = False) -> list:
+    body = []
+    for team in config.TEAMS:
+        body.extend(summarise_team(team, severities))
+    return _wrap_with_top_header(body, severities, quiet=quiet)
+
+
+def report_invalid_target(target: str) -> list:
+    return get_basic_header_and_text_blocks(
+        header_text=f"{target} was not recognised",
+        texts=f"Run `@{settings.SLACK_APP_USERNAME} security usage` to see the valid values for `target`.",
+    )
+
+
+def report_invalid_list_of_targets() -> list:
+    return get_basic_header_and_text_blocks(
+        header_text="Invalid list of targets",
+        texts="List items must all be teams, all be orgs, or all be repos.",
+    )
+
+
+def main(args) -> str:
+    severities = ALL_SEVERITIES if args.all_severities else DEFAULT_SEVERITIES
+    try:
+        blocks = _main(args.target, severities=severities, quiet=args.quiet)
+    except Exception as e:
+        blocks = get_basic_header_and_text_blocks(
+            header_text=f"An error occurred reporting security alerts for {' '.join(args.target)}",
+            texts=str(e),
+        )
+    if not blocks:
+        return ""
+    return json.dumps(blocks)
+
+
+def _main(targets: list[str], severities: list[str], quiet: bool = False) -> list:
+    """
+    Build the response blocks. Returns an empty list when there is nothing to
+    report and quiet=True (which the caller serialises as empty stdout so the
+    dispatcher can skip posting).
+
+    Targets may be:
+      - "all": summarise all teams
+      - team shorthand (e.g. "rap") - full team names with spaces are not supported
+        because the parser splits on whitespace
+      - known repo name (org optional)
+      - org shorthand or full org name
+      - "org/repo" string
+
+    Multiple targets must be of the same type (all teams, all orgs, or all repos).
+    """
+    if "all" in targets:
+        return summarise_all(severities, quiet=quiet)
+
+    # Each target is sorted into one of three groups. Mixing types in one
+    # invocation is rejected below.
+    teams: list[str] = []
+    orgs: list[str] = []
+    repo_full_names: list[str] = []
+
+    for target in targets:
+        # Some repos are names of websites and Slack auto-linkifies them by prepending
+        # http:// (or https:// for some domains)
+        target = target.removeprefix("http://").removeprefix("https://")
+
+        if target in shorthands.TEAMS:
+            teams.append(shorthands.TEAMS[target])
+            continue
+
+        # More than one "/" can never be a valid org/repo (e.g. "a/b/c").
+        if target.count("/") > 1:
+            return report_invalid_target(target)
+
+        if "/" in target:
+            org, repo = target.split("/")
+        elif target in config.REPOS:
+            org, repo = config.REPOS[target]["org"], target
+        else:
+            # No "/" and not a known short repo name - assume it's an org.
+            org, repo = target, None
+
+        org = shorthands.ORGS.get(org, org)
+        if org not in shorthands.ORGS.values():
+            return report_invalid_target(target)
+        if repo:
+            repo_full_names.append(f"{org}/{repo}")
+        else:
+            orgs.append(org)
+
+    # Reject mixed-type lists like `report rap osc` or `report osc airlock`;
+    if sum(bool(x) for x in (teams, orgs, repo_full_names)) > 1:
+        return report_invalid_list_of_targets()
+
+    if teams:
+        body: list = []
+        for team in teams:
+            body.extend(summarise_team(team, severities))
+        return _wrap_with_top_header(body, severities, quiet=quiet)
+
+    if orgs:
+        body = []
+        for org in orgs:
+            body.extend(summarise_org(org, severities))
+        return _wrap_with_top_header(body, severities, quiet=quiet)
+
+    if len(repo_full_names) == 1:
+        # Single-repo report doesn't go through _wrap_with_top_header (it has
+        # its own header), so we need to handle the quiet-with-no-alerts case
+        # explicitly here.
+        reporter = RepoAlertsReporter(repo_full_names[0], severities=severities)
+        if quiet and not any(reporter.get_counts().values()):
+            return []
+        return reporter.report_blocks()
+
+    items = _repos_with_alerts(repo_full_names, severities)
+    body = [
+        get_summary_block(repo_full_name, counts, severities)
+        for repo_full_name, counts in items
+    ]
+    return _wrap_with_top_header(body, severities, quiet=quiet)
+
+
+def get_usage_text(args) -> str:
+    orgs = ", ".join(f"`{k} ({v})`" for k, v in shorthands.ORGS.items())
+    teams = ", ".join(f"`{k} ({v})`" for k, v in shorthands.TEAMS.items())
+    lines = [
+        "Usage for `security report [target]`:",
+        "`report`: Report open critical/high security alerts across all teams.",
+        f"`report [team]`: Report open critical/high security alerts for a known team: {teams}.",
+        f"`report [org]`: Report open critical/high security alerts for a known organisation: {orgs}.",
+        "`report [repo]`:  Report open critical/high security alerts for a known repo (e.g. `report airlock`) or a repo in a known org (e.g. `report os/some-study-repo`).",
+        "To pass multiple targets of the same type (org/team/repo), separate them by spaces.",
+        "",
+        "Use `check` / `check [target]` for the same outputs but with no Slack message when there are no alerts to report.",
+        "Use `report-all` / `report-all [target]` to include medium and low severity alerts as well as critical and high.",
+        "",
+        "Repos monitored, by team:",
+    ]
+    for team in config.TEAMS:
+        repos = sorted(repo for repo, v in config.REPOS.items() if v["team"] == team)
+        lines.append(f"  - {team}: {', '.join(repos) if repos else '(none)'}")
+    return "\n".join(lines)
+
+
+def get_command_line_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+
+    report_parser = subparsers.add_parser("report")
+    report_parser.add_argument(
+        "--target",
+        default="all",
+        action=SplitString,
+        help="Provide multiple targets as a space-separated quoted string, e.g. 'osc ebm'.",
+    )
+    report_parser.add_argument(
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Emit empty output when there is nothing to report (for use with suppress_empty jobs).",
+    )
+    report_parser.add_argument(
+        "--all-severities",
+        action="store_true",
+        default=False,
+        help="Report on critical/high/medium/low alerts instead of only critical/high.",
+    )
+    report_parser.set_defaults(func=main)
+
+    usage_parser = subparsers.add_parser("usage")
+    usage_parser.set_defaults(func=get_usage_text)
+
+    return parser
+
+
+if __name__ == "__main__":
+    try:
+        args = get_command_line_parser().parse_args()
+        print(args.func(args))
+    except Exception as e:
+        print(
+            json.dumps(
+                get_basic_header_and_text_blocks(
+                    header_text="An error occurred", texts=str(e)
+                )
+            )
+        )

--- a/workspace/security/jobs.py
+++ b/workspace/security/jobs.py
@@ -18,6 +18,22 @@ from workspace.utils.github_rest_api import GitHubAPIClient
 # `repo` for private-repo access).
 github_client = GitHubAPIClient(os.environ["DATA_TEAM_GITHUB_API_TOKEN"])
 
+# Local cache of the most recent Dependabot response per (repo, severities),
+# keyed by `"<repo>|<sev1>,<sev2>,…"`. Each entry stores the first-page ETag
+# plus the full alerts list, so we can send `If-None-Match` on subsequent
+# requests and skip re-downloading on 304 Not Modified.
+CACHE_PATH = settings.WRITEABLE_DIR / "security_cache.json"
+
+
+def load_cache() -> dict:
+    if not CACHE_PATH.exists():
+        return {}
+    return json.loads(CACHE_PATH.read_text())
+
+
+def save_cache(cache: dict) -> None:
+    CACHE_PATH.write_text(json.dumps(cache))
+
 
 ALL_SEVERITIES = ["critical", "high", "medium", "low"]
 DEFAULT_SEVERITIES = ["critical", "high"]
@@ -62,16 +78,35 @@ class RepoAlertsReporter:
         self.severities = severities or DEFAULT_SEVERITIES
         self.base_api_url = f"https://api.github.com/repos/{repo_full_name}/"
         self.dependabot_link = get_dependabot_alerts_link(repo_full_name)
-        self.alerts = list(self.get_open_alerts())
+        self.alerts = self.get_open_alerts()
 
-    def get_open_alerts(self):
+    def _cache_key(self) -> str:
+        # Severities are part of the key because the API filters server-side
+        # by `severity=…`; an entry cached for critical/high would silently
+        # return the wrong data for an all-severities request.
+        return f"{self.repo_full_name}|{','.join(self.severities)}"
+
+    def get_open_alerts(self) -> list:
+        """Fetch alerts, sending the cached ETag if available. On 304 we reuse the
+        cached alerts list; on 200 we replace the cache entry with the fresh response.
+        """
+        cache = load_cache()
+        cached = cache.get(self._cache_key(), {})
         url = f"{self.base_api_url}dependabot/alerts"
         params = {
             "state": "open",
             "severity": ",".join(self.severities),
             "per_page": 100,
         }
-        return github_client.get_paginated_json(url, params=params)
+        response = github_client.get_paginated_json(
+            url, params=params, etag=cached.get("etag")
+        )
+        if response.not_modified:
+            return cached["alerts"]
+        alerts = list(response)
+        cache[self._cache_key()] = {"etag": response.etag, "alerts": alerts}
+        save_cache(cache)
+        return alerts
 
     def get_counts(self) -> dict:
         counts = {sev: 0 for sev in self.severities}

--- a/workspace/utils/github_rest_api.py
+++ b/workspace/utils/github_rest_api.py
@@ -28,7 +28,7 @@ class ReadOnlySession(requests.Session):
         return super().request(method, url, *args, **kwargs)
 
 
-# Single session shared by all clients — it has no per-token state (auth
+# Single session shared by all clients - it has no per-token state (auth
 # headers are passed per-request), so sharing the underlying connection pool
 # is safe and tests can patch one location to intercept any client's calls.
 readonly_session = ReadOnlySession()
@@ -69,25 +69,76 @@ class GitHubAPIClient:
         self,
         url: str,
         params: dict | None = None,
+        etag: str | None = None,
         results_key: str | None = None,
-    ):
-        """Yield records across all pages, following the "next" Link header.
+    ) -> "PagedResponse":
+        """Fetch records across all pages, following the "next" Link header.
 
-        Returns a generator so large responses don't have to be materialised at once.
+        Returns a `PagedResponse` - an iterable that yields records lazily
+        (subsequent pages aren't fetched until consumed).
+
+        Optionally, pass an etag from a previous response to send
+        `If-None-Match` headers so callers can cache and reuse data.
+        Callers that don't care about caching can just iterate the result
+        and ignore etag/not_modified entirely.
+
+        Note: the ETag tracks the first page only. This
+        is reliable for endpoints where any change bubbles up to page 1
+        (e.g. lists sorted by created/updated desc), but for endpoints where
+        changes may be on subsequent pages only, alternative forms of caching
+        will be required.
 
         For endpoints whose JSON body is a bare array (e.g. Dependabot
         alerts), leave `results_key` as None. For endpoints that wrap the
         array under a key (e.g. `{"codespaces": [...]}`), pass that key
         so the helper can unwrap each page.
         """
-        while url:
-            response = readonly_session.get(url, headers=self.headers, params=params)
-            response.raise_for_status()
+        headers = dict(self.headers)
+        if etag is not None:
+            headers["If-None-Match"] = etag
+
+        # Fetch page 1 eagerly so the caller can read etag/not_modified before
+        # deciding whether to iterate.
+        response = readonly_session.get(url, headers=headers, params=params)
+        if response.status_code == 304:
+            return PagedResponse(records=iter(()), etag=etag, not_modified=True)
+        response.raise_for_status()
+
+        return PagedResponse(
+            records=self._walk_pages(response, results_key),
+            etag=response.headers.get("ETag"),
+        )
+
+    def _walk_pages(self, response, results_key):
+        """Yield records from `response`, then follow Link rel='next' pages."""
+        while True:
             page = response.json()
             if results_key is not None:
                 page = page[results_key]
             yield from page
             # The Link-header URL already includes the original query string,
-            # don't pass any params on subsequent calls as they'll conflict.
-            params = None
-            url = response.links.get("next", {}).get("url")
+            # so subsequent calls send no extra params.
+            next_url = response.links.get("next", {}).get("url")
+            if not next_url:
+                return
+            response = readonly_session.get(next_url, headers=self.headers)
+            response.raise_for_status()
+
+
+class PagedResponse:
+    """Iterable wrapper around the result of `GitHubAPIClient.get_paginated_json`.
+
+    Iterating yields each record across all pages (subsequent pages fetched
+    lazily). The first page's `ETag` is exposed for callers that want to
+    cache and send `If-None-Match` next time; `not_modified` is True when
+    the caller passed an `etag` that the server accepted (HTTP 304), in
+    which case iteration yields nothing.
+    """
+
+    def __init__(self, records, etag, not_modified=False):
+        self._records = records
+        self.etag = etag
+        self.not_modified = not_modified
+
+    def __iter__(self):
+        return iter(self._records)

--- a/workspace/utils/github_rest_api.py
+++ b/workspace/utils/github_rest_api.py
@@ -1,0 +1,93 @@
+"""Shared, read-only GitHub REST client.
+
+Each workspace job that needs to talk to the GitHub API instantiates a
+`GitHubAPIClient` with its own token (different namespaces use different
+tokens with different scopes). All clients share a single read-only
+`requests.Session` underneath, which refuses any non-GET HTTP method.
+"""
+
+import requests
+
+
+class ReadOnlySession(requests.Session):
+    """A `requests.Session` that refuses any non-GET HTTP method.
+
+    A basic guard against accidentally writing to GitHub via this module.
+    Tokens may have scopes that permit writes (classic PATs can't be
+    narrowed to read-only), so this session enforces read-only at the
+    request layer: any future code that calls .post()/.put()/etc. through
+    `readonly_session` will raise an error.
+    """
+
+    def request(self, method, url, *args, **kwargs):
+        if method.upper() != "GET":
+            raise RuntimeError(
+                f"workspace.utils.github_rest_api is read-only; refusing {method!r} "
+                f"request to {url}."
+            )
+        return super().request(method, url, *args, **kwargs)
+
+
+# Single session shared by all clients — it has no per-token state (auth
+# headers are passed per-request), so sharing the underlying connection pool
+# is safe and tests can patch one location to intercept any client's calls.
+readonly_session = ReadOnlySession()
+
+
+class GitHubAPIClient:
+    """Read-only client for the GitHub REST API.
+
+    Parameters:
+        token: the GitHub PAT (classic or fine-grained) or installation
+            token to authenticate with. The required scopes are
+            endpoint-specific; see each caller's notes for what's needed.
+        api_version: value for the `X-GitHub-Api-Version` header. Pin
+            this so a future GitHub default bump can't silently change
+            response shapes. Override per client when an endpoint expects
+            an older version.
+    """
+
+    # Headers other than Authorization follow GitHub's REST recommendations:
+    #  - `Accept` pins the response media type
+    #  - `User-Agent` identifies us in GitHub's logs (required by GitHub;
+    #    although the requests library's default would technically pass)
+    def __init__(self, token: str, api_version: str = "2026-03-10"):
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "bennettbot",
+            "X-GitHub-Api-Version": api_version,
+        }
+
+    def get_json(self, url: str, params: dict | None = None) -> dict | list:
+        """Single GET, returning the JSON body."""
+        response = readonly_session.get(url, headers=self.headers, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def get_paginated_json(
+        self,
+        url: str,
+        params: dict | None = None,
+        results_key: str | None = None,
+    ):
+        """Yield records across all pages, following the "next" Link header.
+
+        Returns a generator so large responses don't have to be materialised at once.
+
+        For endpoints whose JSON body is a bare array (e.g. Dependabot
+        alerts), leave `results_key` as None. For endpoints that wrap the
+        array under a key (e.g. `{"codespaces": [...]}`), pass that key
+        so the helper can unwrap each page.
+        """
+        while url:
+            response = readonly_session.get(url, headers=self.headers, params=params)
+            response.raise_for_status()
+            page = response.json()
+            if results_key is not None:
+                page = page[results_key]
+            yield from page
+            # The Link-header URL already includes the original query string,
+            # don't pass any params on subsequent calls as they'll conflict.
+            params = None
+            url = response.links.get("next", {}).get("url")

--- a/workspace/utils/repos_config.py
+++ b/workspace/utils/repos_config.py
@@ -174,9 +174,9 @@ CUSTOM_WORKFLOWS_GROUPS = {
 }
 
 
-def get_locations_for_team(team: str) -> list[str]:
+def get_repo_full_names_for_team(team: str) -> list[str]:
     return [f"{v['org']}/{repo}" for repo, v in REPOS.items() if v["team"] == team]
 
 
-def get_locations_for_org(org: str) -> list[str]:
+def get_repo_full_names_for_org(org: str) -> list[str]:
     return [f"{org}/{repo}" for repo, v in REPOS.items() if v["org"] == org]

--- a/workspace/utils/repos_config.py
+++ b/workspace/utils/repos_config.py
@@ -172,3 +172,11 @@ CUSTOM_WORKFLOWS_GROUPS = {
         },
     }
 }
+
+
+def get_locations_for_team(team: str) -> list[str]:
+    return [f"{v['org']}/{repo}" for repo, v in REPOS.items() if v["team"] == team]
+
+
+def get_locations_for_org(org: str) -> list[str]:
+    return [f"{org}/{repo}" for repo, v in REPOS.items() if v["org"] == org]

--- a/workspace/utils/shorthands.py
+++ b/workspace/utils/shorthands.py
@@ -4,3 +4,10 @@ ORGS = {
     "ebm": "ebmdatalab",
     "bo": "bennettoxford",
 }
+
+TEAMS = {
+    "rap": "Team RAP",
+    "rex": "Team REX",
+    "presc": "Team Prescribosaurus",
+    "tech": "Tech shared",
+}

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -58,12 +58,12 @@ def load_cache() -> dict:
     return json.loads(CACHE_PATH.read_text())
 
 
-def get_github_actions_link(location):
-    return f"https://github.com/{location}/actions?query=branch%3Amain"
+def get_github_actions_link(repo_full_name):
+    return f"https://github.com/{repo_full_name}/actions?query=branch%3Amain"
 
 
 class RepoWorkflowReporter:
-    def __init__(self, location):
+    def __init__(self, repo_full_name):
         """
         Retrieves and reports on the status of workflow runs on the main branch in a specified repo.
         Workflows that are not on the main branch are skipped.
@@ -77,12 +77,12 @@ class RepoWorkflowReporter:
         Functions outside of this class are used to generate summary reports from the conclusions returned from get_latest_conclusions() or loaded from the cache file.
 
         Parameters:
-            location: str
-                The location of the repo in the format "org/repo" (e.g. "opensafely/documentation")
+            repo_full_name: str
+                The full name of the repo in the format "org/repo" (e.g. "opensafely/documentation")
         """
-        self.location = location
-        self.base_api_url = f"https://api.github.com/repos/{self.location}/"
-        self.github_actions_link = get_github_actions_link(self.location)
+        self.repo_full_name = repo_full_name
+        self.base_api_url = f"https://api.github.com/repos/{self.repo_full_name}/"
+        self.github_actions_link = get_github_actions_link(self.repo_full_name)
 
         self.workflows = self.get_workflows()  # Dict of workflow_id: workflow_name
         self.workflow_ids = set(self.workflows.keys())
@@ -91,7 +91,7 @@ class RepoWorkflowReporter:
         self.cache = self._load_cache_for_repo()
 
     def _load_cache_for_repo(self) -> dict:
-        cache = load_cache().get(self.location, {})
+        cache = load_cache().get(self.repo_full_name, {})
         if cache.get("version") != self.cache_version:
             return {}
         return cache
@@ -112,7 +112,7 @@ class RepoWorkflowReporter:
         return workflows
 
     def remove_ignored_workflows(self, workflows):
-        skipped = config.IGNORED_WORKFLOWS.get(self.location, [])
+        skipped = config.IGNORED_WORKFLOWS.get(self.repo_full_name, [])
         for workflow_id in skipped:
             workflows.pop(workflow_id, None)
 
@@ -179,7 +179,7 @@ class RepoWorkflowReporter:
 
     def write_cache_to_file(self):
         cache_file_contents = load_cache()
-        cache_file_contents[self.location] = self.cache
+        cache_file_contents[self.repo_full_name] = self.cache
         with open(CACHE_PATH, "w") as f:
             f.write(json.dumps(cache_file_contents))
 
@@ -195,7 +195,7 @@ class RepoWorkflowReporter:
         conclusions = self.get_latest_conclusions()
         lines = [format_text(wf, conclusion) for wf, conclusion in conclusions.items()]
         blocks = [
-            get_header_block(f"Workflows for {self.location}"),
+            get_header_block(f"Workflows for {self.repo_full_name}"),
             get_text_block("\n".join(lines)),  # Show in one block for compactness
             get_text_block(f"<{self.github_actions_link}|View Github Actions>"),
         ]
@@ -222,28 +222,30 @@ def _format_run_url(run_url, link_text):
     return link_text
 
 
-def get_summary_block(location: str, conclusions: list) -> str:
-    link = get_github_actions_link(location)
+def get_summary_block(repo_full_name: str, conclusions: list) -> str:
+    link = get_github_actions_link(repo_full_name)
     emojis = "".join(
         [
             _format_run_url(run_url, get_emoji(conclusion_name))
             for conclusion_name, run_url in conclusions
         ]
     )
-    return get_text_block(f"<{link}|{location}>: {emojis}")
+    return get_text_block(f"<{link}|{repo_full_name}>: {emojis}")
 
 
 def get_success_rate(conclusions) -> float:
     return conclusions.count("success") / len(conclusions)
 
 
-def _summarise(header_text: str, locations: list[str], skip_successful: bool) -> list:
+def _summarise(
+    header_text: str, repo_full_names: list[str], skip_successful: bool
+) -> list:
     unsorted = {}
-    for location in locations:
-        wf_conclusions = RepoWorkflowReporter(location).get_latest_conclusions()
+    for repo_full_name in repo_full_names:
+        wf_conclusions = RepoWorkflowReporter(repo_full_name).get_latest_conclusions()
 
         # Skip reporting missing workflows and failures that are already known
-        known_failure_ids = config.WORKFLOWS_KNOWN_TO_FAIL.get(location, [])
+        known_failure_ids = config.WORKFLOWS_KNOWN_TO_FAIL.get(repo_full_name, [])
         wf_conclusions = {
             k: v
             for k, v in wf_conclusions.items()
@@ -261,21 +263,24 @@ def _summarise(header_text: str, locations: list[str], skip_successful: bool) ->
             == 1
         ):
             continue
-        unsorted[location] = list(wf_conclusions.values())
+        unsorted[repo_full_name] = list(wf_conclusions.values())
 
     key = lambda item: get_success_rate(item[1][0])
     conclusions = sorted(unsorted.items(), key=key)
     blocks = [
         get_header_block(header_text),
-        *[get_summary_block(loc, conc) for loc, conc in conclusions],
+        *[
+            get_summary_block(repo_full_name, conc)
+            for repo_full_name, conc in conclusions
+        ],
     ]
     return blocks
 
 
 def summarise_team(team: str, skip_successful: bool) -> list:
     header = f"Workflows for {team}"
-    locations = config.get_locations_for_team(team)
-    return _summarise(header, locations, skip_successful)
+    repo_full_names = config.get_repo_full_names_for_team(team)
+    return _summarise(header, repo_full_names, skip_successful)
 
 
 def summarise_all(skip_successful) -> list:
@@ -292,8 +297,8 @@ def summarise_all(skip_successful) -> list:
 
 def summarise_org(org, skip_successful) -> list:
     header_text = f"Workflows for {org} repos"
-    locations = config.get_locations_for_org(org)
-    blocks = _summarise(header_text, locations, skip_successful)
+    repo_full_names = config.get_repo_full_names_for_org(org)
+    blocks = _summarise(header_text, repo_full_names, skip_successful)
     return blocks
 
 
@@ -310,16 +315,16 @@ def summarise_workflows_group(group: str, skip_successful: bool) -> list:
         )
 
     conclusions = {}
-    for location, workflow_ids in group_config["workflows"].items():
-        wf_conclusions = RepoWorkflowReporter(location).get_latest_conclusions()
-        conclusions[location] = [
+    for repo_full_name, workflow_ids in group_config["workflows"].items():
+        wf_conclusions = RepoWorkflowReporter(repo_full_name).get_latest_conclusions()
+        conclusions[repo_full_name] = [
             wf_conclusions.get(wf_id, "missing") for wf_id in workflow_ids
         ]
     blocks = [
         get_header_block(group_config["header_text"]),
         *[
-            get_summary_block(loc, conc)
-            for loc, conc in conclusions.items()
+            get_summary_block(repo_full_name, conc)
+            for repo_full_name, conc in conclusions.items()
             if not (skip_successful and get_success_rate(conc) == 1)
         ],
     ]
@@ -361,10 +366,11 @@ def _main(targets: list[str], skip_successful: bool) -> str:
 
     # Validation
     orgs = []
-    locations = []
+    repo_full_names = []
     for target in targets:
-        # Some repos are names of websites and slack prepends http:// to them
-        target = target.replace("http://", "")
+        # Some repos are names of websites and Slack auto-linkifies them by prepending
+        # http:// (or https:// for some domains)
+        target = target.removeprefix("http://").removeprefix("https://")
         if target.count("/") > 1:
             return report_invalid_target(target)
 
@@ -379,25 +385,27 @@ def _main(targets: list[str], skip_successful: bool) -> str:
         if org not in shorthands.ORGS.values():
             return report_invalid_target(target)
         if repo:
-            locations.append(f"{org}/{repo}")
+            repo_full_names.append(f"{org}/{repo}")
         else:
             orgs.append(org)
 
-    if orgs and not locations:  # Summarise the org(s)
+    if orgs and not repo_full_names:  # Summarise the org(s)
         blocks = []
         for org in orgs:
             blocks.extend(summarise_org(org, skip_successful))
         return json.dumps(blocks)
 
-    elif len(locations) != len(targets):
+    elif len(repo_full_names) != len(targets):
         return report_invalid_list_of_targets()
 
-    elif len(locations) == 1:
+    elif len(repo_full_names) == 1:
         # Single repo usage: Report status for all workflows in a specified repo
-        return RepoWorkflowReporter(locations[0]).report()
+        return RepoWorkflowReporter(repo_full_names[0]).report()
 
     else:  # Summarise the list of repos requested
-        return json.dumps(_summarise("Workflows summary", locations, skip_successful))
+        return json.dumps(
+            _summarise("Workflows summary", repo_full_names, skip_successful)
+        )
 
 
 def get_text_blocks_for_key(args) -> str:

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 import requests
 
 from bennettbot import settings
+from workspace.utils import repos_config as config
 from workspace.utils import shorthands
 from workspace.utils.argparse import SplitString
 from workspace.utils.blocks import (
@@ -14,7 +15,6 @@ from workspace.utils.blocks import (
     get_header_block,
     get_text_block,
 )
-from workspace.workflows import config
 
 
 CACHE_PATH = settings.WRITEABLE_DIR / "workflows_cache.json"
@@ -32,16 +32,6 @@ EMOJI = {
 
 def get_emoji(conclusion) -> str:
     return EMOJI.get(conclusion, EMOJI["other"])
-
-
-def get_locations_for_team(team: str) -> list[str]:
-    return [
-        f"{v['org']}/{repo}" for repo, v in config.REPOS.items() if v["team"] == team
-    ]
-
-
-def get_locations_for_org(org: str) -> list[str]:
-    return [f"{org}/{repo}" for repo, v in config.REPOS.items() if v["org"] == org]
 
 
 def report_invalid_target(target) -> str:
@@ -293,7 +283,7 @@ def _summarise(header_text: str, locations: list[str], skip_successful: bool) ->
 
 def summarise_team(team: str, skip_successful: bool) -> list:
     header = f"Workflows for {team}"
-    locations = get_locations_for_team(team)
+    locations = config.get_locations_for_team(team)
     return _summarise(header, locations, skip_successful)
 
 
@@ -311,7 +301,7 @@ def summarise_all(skip_successful) -> list:
 
 def summarise_org(org, skip_successful) -> list:
     header_text = f"Workflows for {org} repos"
-    locations = get_locations_for_org(org)
+    locations = config.get_locations_for_org(org)
     blocks = _summarise(header_text, locations, skip_successful)
     return blocks
 

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -4,8 +4,6 @@ import os
 from datetime import datetime
 from urllib.parse import urljoin
 
-import requests
-
 from bennettbot import settings
 from workspace.utils import repos_config as config
 from workspace.utils import shorthands
@@ -15,10 +13,12 @@ from workspace.utils.blocks import (
     get_header_block,
     get_text_block,
 )
+from workspace.utils.github_rest_api import GitHubAPIClient
 
 
 CACHE_PATH = settings.WRITEABLE_DIR / "workflows_cache.json"
-TOKEN = os.environ["DATA_TEAM_GITHUB_API_TOKEN"]  # requires "read:project" and "repo"
+# Requires `repo` scope for Actions workflows/runs on private repos.
+github_client = GitHubAPIClient(os.environ["DATA_TEAM_GITHUB_API_TOKEN"])
 EMOJI = {
     "success": ":large_green_circle:",
     "running": ":large_yellow_circle:",
@@ -50,15 +50,6 @@ def report_invalid_list_of_targets() -> str:
         ],
     )
     return json.dumps(blocks)
-
-
-def get_api_result_as_json(url: str, params: dict | None = None) -> dict:
-    params = params or {}
-    params["format"] = "json"
-    headers = {"Authorization": f"Bearer {TOKEN}"}
-    response = requests.get(url, headers=headers, params=params)
-    response.raise_for_status()
-    return response.json()
 
 
 def load_cache() -> dict:
@@ -112,7 +103,7 @@ class RepoWorkflowReporter:
 
     def _get_json_response(self, path, params=None):
         url = urljoin(self.base_api_url, path)
-        return get_api_result_as_json(url, params)
+        return github_client.get_json(url, params)
 
     def get_workflows(self) -> dict:
         results = self._get_json_response("actions/workflows")["workflows"]


### PR DESCRIPTION
Adds a new job category that reports open critical/high Dependabot security alerts
across our monitored repos, plus some refactoring to pull out the GitHub REST API utilities and
reuse them across workflows/codespaces/security jobs.

Structure (code and slack commands) largely follow the existing workflows jobs.

New slack commands (all restricted):

@bennettbot security report                # all teams, critical/high severity only
@bennettbot security report [target]       # by team / org / repo
@bennettbot security check                 # like `report` but stays silent if nothing to report
@bennettbot security check [target]
@bennettbot security report-all            # all severities (critical/high/medium/low )
@bennettbot security report-all [target]
@bennettbot security usage                 # help

target accepts a team shorthand (rap/rex/presc/tech), an org shorthand (os/osc/ebm/bo), a
known repo (airlock), or org/repo. Multi-target requests must all be the same shape.

A few changes that the security job uses but aren't security-specific:

- suppress_empty job option: when job produces empty stdout, the dispatcher
skips posting to Slack instead of sending the "No output found" placeholder. Means we can avoid
cluttering a slack channel when there's nothing to report.
- Reaction on completion: every Slack-triggered job now gets a :white_check_mark: (success)
or :x: (failure) reaction on the requesting message. Combined with suppress_empty, that's the
only signal you get for a quiet check.
- The new shared GitHubAPIClient class shared module enforces read-only access. We need to use
classic tokens with `repo` scope which allows write access, which has made me nervous for a while.
This will stop us using non-GET requests via the client, and a test checks all workspace python
files for any non-GET requests that might creep in in the future.

Example output (all targets):
<img width="1112" height="467" alt="image" src="https://github.com/user-attachments/assets/953301b3-e737-4197-a3a6-9a8bf6c0cad1" />

Example output (single team):
<img width="1121" height="221" alt="image" src="https://github.com/user-attachments/assets/1999a611-db3e-4c05-b6a9-edf2468f5512" />

Example report-all, single team
<img width="1108" height="229" alt="image" src="https://github.com/user-attachments/assets/0616930f-af28-490e-8437-847623a3e598" />

(No example for the check, because it doesn't do anything except :heavy_check_mark: the message, but I confirm I've tried it in the test workspace and it works)

Will close https://github.com/opensafely-core/security/issues/64 (when we add the slack reminders to run the new command)

Also closes #787