### PR TITLE
Allow concurrent scheduled jobs of the same type with different args

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ to OpenPrescribing jobs. New jobs will likely only require `"schedule_job"` slac
 commands.
 
 
+## Scheduling behaviour
+
+- `schedule_job` deduplicates on **both** `job_type` and `args`. Scheduling
+  the same `(job_type, args)` again while a matching job is still pending
+  updates that pending job (channel, thread, start time). Scheduling the same
+  `job_type` with **different** args queues a separate, independent job — so
+  e.g. `workflows show osc` and `workflows show osc/airlock` coexist rather
+  than one cancelling the other.
+- The dispatcher only runs one job per `job_type` at a time, regardless of
+  args. Pending jobs of the same type with different args therefore run
+  serially in queue order.
+- `cancel_job` removes **all** pending jobs of a given `job_type`, regardless
+  of args.
+- Suppressions (`schedule_suppression` / `cancel_suppression`) operate on
+  `job_type` only and are unrelated to the args-aware queueing above.
+- As noted in the section above, the `cancel_job`, `schedule_suppression`
+  and `cancel_suppression` actions are currently only used by OpenPrescribing
+  (`op`) jobs — new jobs typically only need `schedule_job`.
+
+
 ## Example job config
 
 ### Simple bash command

--- a/bennettbot/scheduler.py
+++ b/bennettbot/scheduler.py
@@ -12,11 +12,14 @@ def schedule_job(
 ):
     """Schedule job to be run.
 
-    Only one job of any type may be scheduled.  If a job is already scheduled
-    but isn't running yet and another job of the same type is scheduled, the
-    record of the first job is updated.
+    Only one job with a given (type, args) combination may be scheduled.  If
+    a matching job is already scheduled but isn't running yet and another job
+    with the same (type, args) is scheduled, the record of the first job is
+    updated.
 
-    If a job is already running, another job of that type may be scheduled.
+    Jobs with the same type but different args are treated as independent and
+    coexist in the queue.  The dispatcher still only runs one job per type at
+    a time (see reserve_job), so they execute serially.
 
     `message_ts` is the timestamp of the Slack message that triggered the job,
     so the dispatcher can react to it on completion. May be None for
@@ -25,28 +28,27 @@ def schedule_job(
     Returns a boolean indicating whether an existing job was already running.
     """
 
+    start_after = _now() + timedelta(seconds=delay_seconds)
+    args = json.dumps(args, sort_keys=True)
+
     sql = """
-    SELECT id, started_at IS NOT NULL AS has_started
+    SELECT id, args, started_at IS NOT NULL AS has_started
     FROM job
     WHERE type = ?
     ORDER BY has_started
     """
 
-    start_after = _now() + timedelta(seconds=delay_seconds)
-    args = json.dumps(args)
-
     with closing(get_connection()) as conn:
         with conn:
-            existing_jobs = list(conn.execute(sql, [type_]))
-        existing_job_running = False
-        if len(existing_jobs) == 0:
-            _create_job(
-                conn, type_, args, channel, thread_ts, message_ts, start_after, is_im
-            )
-        elif len(existing_jobs) == 1:
-            job = existing_jobs[0]
-            if job["has_started"]:
-                existing_job_running = True
+            same_type_jobs = list(conn.execute(sql, [type_]))
+
+        # Do we have a running job of the same type (irrespective of args)?
+        existing_job_type_running = any(j["has_started"] for j in same_type_jobs)
+        # Find matching jobs including args
+        matching_jobs = [j for j in same_type_jobs if j["args"] == args]
+
+        match len(matching_jobs):
+            case 0:
                 _create_job(
                     conn,
                     type_,
@@ -57,21 +59,48 @@ def schedule_job(
                     start_after,
                     is_im,
                 )
-            else:
-                id_ = job["id"]
+            case 1:
+                job = matching_jobs[0]
+                if job["has_started"]:
+                    _create_job(
+                        conn,
+                        type_,
+                        args,
+                        channel,
+                        thread_ts,
+                        message_ts,
+                        start_after,
+                        is_im,
+                    )
+                else:
+                    _update_job(
+                        conn,
+                        job["id"],
+                        args,
+                        channel,
+                        thread_ts,
+                        message_ts,
+                        start_after,
+                    )
+            case 2:
+                # We order by has_started ASC, and we can only have one matching job running
+                # Update the not-running job (always the first one) with the current requested job
+                # sanity check
+                assert not matching_jobs[0]["has_started"]
+                assert matching_jobs[1]["has_started"]
                 _update_job(
-                    conn, id_, args, channel, thread_ts, message_ts, start_after
+                    conn,
+                    matching_jobs[0]["id"],
+                    args,
+                    channel,
+                    thread_ts,
+                    message_ts,
+                    start_after,
                 )
-        elif len(existing_jobs) == 2:
-            assert not existing_jobs[0]["has_started"]
-            assert existing_jobs[1]["has_started"]
-            existing_job_running = True
-            id_ = existing_jobs[0]["id"]
-            _update_job(conn, id_, args, channel, thread_ts, message_ts, start_after)
-        else:
-            assert False
+            case _:  # pragma: no cover
+                assert False
 
-    return existing_job_running
+    return existing_job_type_running
 
 
 def _create_job(conn, type_, args, channel, thread_ts, message_ts, start_after, is_im):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -43,7 +43,20 @@ def test_schedule_job_with_no_jobs_of_same_type_already_scheduled():
     assert_job_matches(jj[0], "good_job", {"k": "v"}, "channel", T(0), None)
 
 
-def test_schedule_job_with_job_of_same_type_scheduled():
+def test_schedule_job_with_same_type_and_args_scheduled_overwrites():
+    assert_no_running_job(
+        scheduler.schedule_job("good_job", {"k": "v"}, "channel", TS, 0)
+    )
+    assert_no_running_job(
+        scheduler.schedule_job("good_job", {"k": "v"}, "channel1", TS, 10)
+    )
+
+    jj = scheduler.get_jobs_of_type("good_job")
+    assert len(jj) == 1
+    assert_job_matches(jj[0], "good_job", {"k": "v"}, "channel1", T(10), None)
+
+
+def test_schedule_job_with_same_type_different_args_scheduled_coexists():
     assert_no_running_job(
         scheduler.schedule_job("good_job", {"k": "v"}, "channel", TS, 0)
     )
@@ -52,8 +65,22 @@ def test_schedule_job_with_job_of_same_type_scheduled():
     )
 
     jj = scheduler.get_jobs_of_type("good_job")
+    assert len(jj) == 2
+    assert_job_matches(jj[0], "good_job", {"k": "v"}, "channel", T(0), None)
+    assert_job_matches(jj[1], "good_job", {"k": "w"}, "channel1", T(10), None)
+
+
+def test_schedule_job_args_match_ignores_dict_key_order():
+    assert_no_running_job(
+        scheduler.schedule_job("good_job", {"a": 1, "b": 2}, "channel", TS, 0)
+    )
+    assert_no_running_job(
+        scheduler.schedule_job("good_job", {"b": 2, "a": 1}, "channel1", TS, 10)
+    )
+
+    jj = scheduler.get_jobs_of_type("good_job")
     assert len(jj) == 1
-    assert_job_matches(jj[0], "good_job", {"k": "w"}, "channel1", T(10), None)
+    assert_job_matches(jj[0], "good_job", {"a": 1, "b": 2}, "channel1", T(10), None)
 
 
 def test_schedule_job_with_job_of_same_type_running(freezer):
@@ -101,9 +128,44 @@ def test_schedule_job_with_job_of_same_type_running_and_another_scheduled(freeze
         scheduler.schedule_job("good_job", ["args2"], "channel2", TS, 15)
     )
     jj = scheduler.get_jobs_of_type("good_job")
+    assert len(jj) == 3
+    assert_job_matches(jj[0], "good_job", {"k": "v"}, "channel", T(0), T(5))
+    assert_job_matches(jj[1], "good_job", {"k": "w"}, "channel1", T(10), None)
+    assert_job_matches(jj[2], "good_job", ["args2"], "channel2", T(20), None)
+
+
+def test_schedule_job_with_running_and_pending_same_args_updates_pending(freezer):
+    scheduler.schedule_job("good_job", {"k": "v"}, "channel", TS, 0)
+    freezer.move_to(T(5))
+    scheduler.reserve_job()
+    assert_running_job(
+        scheduler.schedule_job("good_job", {"k": "w"}, "channel1", TS, 5)
+    )
+
+    assert_running_job(
+        scheduler.schedule_job("good_job", {"k": "w"}, "channel2", TS, 15)
+    )
+    jj = scheduler.get_jobs_of_type("good_job")
     assert len(jj) == 2
     assert_job_matches(jj[0], "good_job", {"k": "v"}, "channel", T(0), T(5))
-    assert_job_matches(jj[1], "good_job", ["args2"], "channel2", T(20), None)
+    assert_job_matches(jj[1], "good_job", {"k": "w"}, "channel2", T(20), None)
+
+
+def test_schedule_job_with_same_args_running_and_pending_updates_pending(freezer):
+    scheduler.schedule_job("good_job", {"k": "v"}, "channel", TS, 0)
+    freezer.move_to(T(5))
+    scheduler.reserve_job()
+    assert_running_job(
+        scheduler.schedule_job("good_job", {"k": "v"}, "channel1", TS, 5)
+    )
+
+    assert_running_job(
+        scheduler.schedule_job("good_job", {"k": "v"}, "channel2", TS, 15)
+    )
+    jj = scheduler.get_jobs_of_type("good_job")
+    assert len(jj) == 2
+    assert_job_matches(jj[0], "good_job", {"k": "v"}, "channel", T(0), T(5))
+    assert_job_matches(jj[1], "good_job", {"k": "v"}, "channel2", T(20), None)
 
 
 def test_cancel_job_with_no_jobs_of_same_type_scheduled():


### PR DESCRIPTION
`schedule_job` now matches existing jobs on both `job_type` and `args`, so commands like `workflows show osc` and `workflows show osc/airlock` coexist in the queue rather than the second silently overwriting the first.

Note that this only affects jobs with the "schedule_job" action, not schedule_job/cancel_job/cancel_suppression; those are only used by op and are unlikely to be used in future by other jobs..

Fixes #785 