### PR TITLE
Add Codespaces review reminder to Dependabot rota

### DIFF
--- a/tests/workspace/test_dependabot_rota.py
+++ b/tests/workspace/test_dependabot_rota.py
@@ -35,6 +35,7 @@ EXTRA_TEXT = (
     "|Combined link>. "
     "Merge any outstanding non-NPM Dependabot/update-dependencies-action PRs."
     "\nReview Thomas' PRs for NPM updates.\n"
+    "Please also review the Codespaces at risk report.\n"
 )
 
 

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -71,6 +71,7 @@ def report_rota() -> str:
         f"\nReview repos {repo_links_text}. <{combined_link}|Combined link>. "
         "Merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\n"
         "Review Thomas' PRs for NPM updates.\n"
+        "Please also review the Codespaces at risk report.\n"
     )
 
     return DependabotRotaReporter(title="Dependabot rota").report(extra_text)


### PR DESCRIPTION
## Describe your changes
Update the weekly Dependabot rota message to remind the rota owner to also review the Codespaces at Risk report.
## Issue ticket number and link
https://github.com/bennettoxford/bennettbot/issues/897
## If adding/updating a custom BennettBot command, please check:

- [x] Unit tests added and coverage passing - updated existing test
- [x] Slack config updated (`bennettbot/job_configs.py`) - not needed
- [x] Tested manually using slack test environment (or ask a member of the tech team to test your branch for you)
<img width="2943" height="557" alt="Screenshot from 2026-06-23 10-24-04" src="https://github.com/user-attachments/assets/2d015845-11ab-4ba3-99a4-390dd6b911b3" />
