### PR TITLE
Add extra note to example repo-config

### DIFF
--- a/repos_config.sample.yaml
+++ b/repos_config.sample.yaml
@@ -1,5 +1,8 @@
+# NOTE: THIS FILE REPRESENTS EXAMPLE CONFIG ONLY. CHANGES MADE HERE WILL NOT BE
+# AUTOMATICALLY APPLIED TO PRODUCTION
+#
 # Example repos config for bennettbot.
-# Created: 2026-06-10; this represents the state of production config at this time.
+# Updated: 2026-06-23; this represents the state of production config at this time.
 # Copy this file to $WRITEABLE_DIR/repos_config.yaml and edit there;
 # production updates do not require a code change.
 


### PR DESCRIPTION
Add an extra all-caps warning to the repo-config example to try to make it more obvious that it's an example only and production changes need to be made elsewhere.